### PR TITLE
fixes async event list downloads

### DIFF
--- a/app/controllers/insieme/events_controller.rb
+++ b/app/controllers/insieme/events_controller.rb
@@ -17,6 +17,17 @@ module Insieme
                                    :spezielle_unterkunft, :kursart]
       ]
 
+      alias_method_chain :render_tabular_in_background, :custom_filename
+
+    end
+
+    def render_tabular_in_background_with_custom_filename(format)
+      job = ::Export::EventsExportJob.new(format,
+                                    current_person.id,
+                                    event_filter, {})
+      AsyncDownloadCookie.new(cookies).set(job.filename, format)
+      job.enqueue!
+      flash[:notice] = translate(:export_enqueued)
     end
 
     private

--- a/app/jobs/insieme/export/events_export_job.rb
+++ b/app/jobs/insieme/export/events_export_job.rb
@@ -16,7 +16,7 @@ module Insieme
 
     def initialize_with_insieme(*args)
       initialize_without_insieme(*args)
-      @tempfile_name = filename
+      @options[:filename] = overwrite_filename
     end
 
     def data_with_insieme
@@ -34,10 +34,10 @@ module Insieme
       "::Export::Tabular::Events::#{list_type}".constantize
     end
 
-    def filename
+    def overwrite_filename
       vid = parent.vid.present? ? "_vid#{parent.vid}" : ''
       bsv = parent.bsv_number.present? ? "_bsv#{parent.bsv_number}" : ''
-      "#{filename_prefix}#{vid}#{bsv}_#{group_name}_#{year}.#{@format}"
+      AsyncDownloadFile.create_name("#{filename_prefix}#{vid}#{bsv}_#{group_name}_#{year}", user.id)
     end
 
     def aggregate_course?

--- a/app/models/group/kollektivmitglieder.rb
+++ b/app/models/group/kollektivmitglieder.rb
@@ -48,5 +48,5 @@ class Group::Kollektivmitglieder < Group
 
   roles Kollektivmitglied,
         KollektivmitgliedMitAbo
-  self.default_role = Kollektivmitglied
+  self.default_role = KollektivmitgliedMitAbo
 end

--- a/app/models/group/passivmitglieder.rb
+++ b/app/models/group/passivmitglieder.rb
@@ -49,5 +49,5 @@ class Group::Passivmitglieder < Group
   roles Passivmitglied,
         PassivmitgliedMitAbo
 
-  self.default_role = Passivmitglied
+  self.default_role = PassivmitgliedMitAbo
 end

--- a/spec/jobs/insieme/export/events_export_job_spec.rb
+++ b/spec/jobs/insieme/export/events_export_job_spec.rb
@@ -9,7 +9,7 @@ require 'spec_helper'
 
 describe Insieme::Export::EventsExportJob do
 
-  subject { Export::EventsExportJob.new(:csv, person.id, event_filter) }
+  subject { Export::EventsExportJob.new(:csv, person.id, event_filter, {}) }
 
   let(:event_filter) { Event::Filter.new(type, 'all', group, 2012, false) }
 
@@ -28,7 +28,8 @@ describe Insieme::Export::EventsExportJob do
 
       it 'creates detail export for cources' do
         expect(subject.exporter_class).to eq(Export::Tabular::Events::DetailList)
-        expect(subject.filename).to eq('course_vid42_bsv99_insieme-schweiz_2012.csv')
+        expect(subject.filename).to start_with('course_vid42_bsv99_insieme-schweiz_2012')
+        expect(subject.filename).to end_with("-#{person.id}")
         expect(subject.data).to be_present
       end
     end
@@ -38,7 +39,8 @@ describe Insieme::Export::EventsExportJob do
 
       it 'creates detail export for cources' do
         expect(subject.exporter_class).to eq(Export::Tabular::Events::ShortList)
-        expect(subject.filename).to eq('course_vid42_bsv99_insieme-schweiz_2012.csv')
+        expect(subject.filename).to start_with('course_vid42_bsv99_insieme-schweiz_2012')
+        expect(subject.filename).to end_with("-#{person.id}")
         expect(subject.data).to be_present
       end
     end
@@ -60,7 +62,7 @@ describe Insieme::Export::EventsExportJob do
       it 'creates detail export for aggregate courses' do
         group.update_attributes!(vid: 42, bsv_number: '99')
         expect(subject.exporter_class).to eq Export::Tabular::Events::AggregateCourse::DetailList
-        expect(subject.filename).to eq('aggregate_course_vid42_bsv99_kanton-bern_2012.csv')
+        expect(subject.filename).to start_with('aggregate_course_vid42_bsv99_kanton-bern_2012')
       end
     end
 
@@ -70,7 +72,7 @@ describe Insieme::Export::EventsExportJob do
       it 'creates short export for aggregate courses' do
         group.update_attributes!(vid: 42, bsv_number: '99')
         expect(subject.exporter_class).to eq Export::Tabular::Events::AggregateCourse::ShortList
-        expect(subject.filename).to eq('aggregate_course_vid42_bsv99_kanton-bern_2012.csv')
+        expect(subject.filename).to start_with('aggregate_course_vid42_bsv99_kanton-bern_2012')
       end
     end
 


### PR DESCRIPTION
async download did not work because job gives the file another name, than the one passed, so the regular method cannot be used, as the name of the created file and the name in the async cookie did not match.