### PR TITLE
Vorhandene Notizen aus dem Vorjahr kopieren können

### DIFF
--- a/app/assets/javascripts/_cost_accounting_note_copier.js.coffee
+++ b/app/assets/javascripts/_cost_accounting_note_copier.js.coffee
@@ -2,19 +2,20 @@ app = window.App ||= {}
 
 class app.CostAccountingNoteCopier
   constructor: ->
-    @target = $('#cost_accounting_record_aufteilung_kontengruppen')[0]
-    @source = $('#vorheriger-kommentar')[0]
-    @container = '#cost_accounting_note_copy'
 
   copy: ->
-    @target.value = @source.innerHTML.trim()
+    target = $('#cost_accounting_record_aufteilung_kontengruppen')[0]
+    source = $('#vorheriger-kommentar')[0]
+
+    target.value = source.innerHTML.trim()
 
   bind: ->
     self = this
+    container = '#cost_accounting_note_copy'
 
-    $(document).on 'click', "#{@container} a", (e) ->
+    $(document).on 'click', "#{container} a", (e) ->
       e.preventDefault()
       self.copy()
 
-    $(@container).removeClass('hidden')
+    $(container).removeClass('hidden')
 

--- a/app/assets/javascripts/_cost_accounting_note_copier.js.coffee
+++ b/app/assets/javascripts/_cost_accounting_note_copier.js.coffee
@@ -1,0 +1,20 @@
+app = window.App ||= {}
+
+class app.CostAccountingNoteCopier
+  constructor: ->
+    @target = $('#cost_accounting_record_aufteilung_kontengruppen')[0]
+    @source = $('#vorheriger-kommentar')[0]
+    @container = '#cost_accounting_note_copy'
+
+  copy: ->
+    @target.value = @source.innerHTML.trim()
+
+  bind: ->
+    self = this
+
+    $(document).on 'click', "#{@container} a", (e) ->
+      e.preventDefault()
+      self.copy()
+
+    $(@container).removeClass('hidden')
+

--- a/app/assets/javascripts/wagon.js.coffee
+++ b/app/assets/javascripts/wagon.js.coffee
@@ -4,6 +4,7 @@
 #  https://github.com/hitobito/hitobito_insieme.
 
 #= require ./_cost_accounting_calculator.js.coffee
+#= require ./_cost_accounting_note_copier.js.coffee
 
 $(document).on('click', '.cancel[href="#"]', (event) ->
   $(this).closest('form').get(0).reset())

--- a/app/controllers/cost_accounting_controller.rb
+++ b/app/controllers/cost_accounting_controller.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-#  Copyright (c) 2012-2014, insieme Schweiz. This file is part of
+#  Copyright (c) 2012-2020, insieme Schweiz. This file is part of
 #  hitobito_insieme and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_insieme.
@@ -11,7 +11,7 @@ class CostAccountingController < ReportingBaseController
 
   self.remember_params = [:year]
 
-  helper_method :report, :table
+  helper_method :report, :table, :previous_entry
 
   def index
     table
@@ -27,6 +27,12 @@ class CostAccountingController < ReportingBaseController
   def entry
     @record ||= CostAccountingRecord.where(group_id: group.id, year: year, report: params[:report]).
                                      first_or_initialize
+  end
+
+  def previous_entry
+    @previous_entry ||= entry.class.where(
+      group_id: group.id, year: (year - 1), report: params[:report]
+    ).first_or_initialize
   end
 
   def report

--- a/app/controllers/cost_accounting_controller.rb
+++ b/app/controllers/cost_accounting_controller.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 #  Copyright (c) 2012-2020, insieme Schweiz. This file is part of
 #  hitobito_insieme and licensed under the Affero General Public License version 3
@@ -25,8 +25,8 @@ class CostAccountingController < ReportingBaseController
   private
 
   def entry
-    @record ||= CostAccountingRecord.where(group_id: group.id, year: year, report: params[:report]).
-                                     first_or_initialize
+    @entry ||= CostAccountingRecord.where(group_id: group.id, year: year, report: params[:report])
+                                   .first_or_initialize
   end
 
   def previous_entry
@@ -36,7 +36,7 @@ class CostAccountingController < ReportingBaseController
   end
 
   def report
-    @report ||= entry.report_class || fail(ActiveRecord::RecordNotFound)
+    @report ||= entry.report_class || raise(ActiveRecord::RecordNotFound)
   end
 
   def table

--- a/app/controllers/reporting_base_controller.rb
+++ b/app/controllers/reporting_base_controller.rb
@@ -1,6 +1,6 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2012-2014, insieme Schweiz. This file is part of
+#  Copyright (c) 2012-2020, insieme Schweiz. This file is part of
 #  hitobito_insieme and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_insieme.
@@ -25,8 +25,7 @@ class ReportingBaseController < ApplicationController
 
   after_save :set_success_notice
 
-  def edit
-  end
+  def edit; end
 
   def update
     entry.attributes = permitted_params

--- a/app/views/cost_accounting/edit.html.haml
+++ b/app/views/cost_accounting/edit.html.haml
@@ -31,8 +31,13 @@
                             help_inline: t('.kontengruppen', kontengruppen: report.kontengruppe))
 
   - if report.editable_fields.include?('aufteilung_kontengruppen')
-    = f.labeled_input_field(:aufteilung_kontengruppen,
-                            placeholder: t('.remarks_placeholder'))
+    = f.labeled_input_field(:aufteilung_kontengruppen, placeholder: t('.remarks_placeholder'))
+    - if previous_entry.aufteilung_kontengruppen.present?
+      #cost_accounting_note_copy.hidden
+        = f.labeled(:copy_previous_notes, '&nbsp;'.html_safe) do
+          = action_button(t('.copy_previous_notes'), '#', :copy)
+      #vorheriger-kommentar.hidden
+        = previous_entry.aufteilung_kontengruppen
 
   = cost_accounting_input_fields(f, :abgrenzung_fibu)
 
@@ -54,3 +59,4 @@
 
 - content_for(:javascripts) do
   new App.CostAccountingCalculator().updateValues();
+  new App.CostAccountingNoteCopier().bind();

--- a/config/locales/views.insieme.de.yml
+++ b/config/locales/views.insieme.de.yml
@@ -76,6 +76,7 @@ de:
       ertrag_ko_re: Ertrag KoRe
       kontengruppen: "Kontengruppe(n) %{kontengruppen}"
       remarks_placeholder: Hier können Sie Ihre Notizen oder Erklärungen anbringen (z.B. wie sich Aufwand auf Kontengruppen verteilt)
+      copy_previous_notes: Notizen aus Vorjahr kopieren
 
   course_reporting:
     client_statistics:

--- a/spec/regressions/cost_accounting_controller_spec.rb
+++ b/spec/regressions/cost_accounting_controller_spec.rb
@@ -30,7 +30,7 @@ describe CostAccountingController, type: :controller  do
       it 'renders' do
         get :edit, params: { id: group.id, year: year, report: report }
         is_expected.to render_template('edit')
-        expect(assigns(:record)).to be_new_record
+        expect(assigns(:entry)).to be_new_record
       end
     end
 
@@ -150,7 +150,7 @@ describe CostAccountingController, type: :controller  do
       it 'renders' do
         get :edit, params: { id: group.id, year: year, report: report }
         is_expected.to render_template('edit')
-        expect(assigns(:record)).to be_persisted
+        expect(assigns(:entry)).to be_persisted
       end
     end
 


### PR DESCRIPTION
Wenn Notizen aus dem Vorjahr vorhanden sind, wird ein Button angeboten, diese in das aktuelle Formular zu übernehmen. Dort kann es dann normal weiter bearbeitet werden. Wenn keine Notizen vorhanden sind, kein Vorjahresreport vorhande ist oder schlicht kein JS aktiviert ist, passiert nichts.

fixes #32 