### PR TITLE
Medien und Publikationen in Kostenrechnung

### DIFF
--- a/app/domain/vp2020/cost_accounting/report/time_distributed.rb
+++ b/app/domain/vp2020/cost_accounting/report/time_distributed.rb
@@ -16,7 +16,8 @@ module Vp2020::CostAccounting
                        tageskurse
                        jahreskurse
                        lufeb
-                       mittelbeschaffung)
+                       mittelbeschaffung
+                       medien_und_publikationen)
 
       self.used_fields += %w(verwaltung)
 

--- a/app/domain/vp2020/cost_accounting/report/total_personalaufwand.rb
+++ b/app/domain/vp2020/cost_accounting/report/total_personalaufwand.rb
@@ -27,7 +27,8 @@ module Vp2020::CostAccounting
                               tageskurse
                               jahreskurse
                               lufeb
-                              mittelbeschaffung)
+                              mittelbeschaffung
+                              medien_und_publikationen)
 
       define_summed_field_methods
 

--- a/app/domain/vp2020/cost_accounting/report/total_umlagen.rb
+++ b/app/domain/vp2020/cost_accounting/report/total_umlagen.rb
@@ -14,6 +14,7 @@ module Vp2020::CostAccounting
                                umlage_verwaltung)
 
       self.summed_fields = %w(beratung
+                              medien_und_publikationen
                               treffpunkte
                               blockkurse
                               tageskurse

--- a/app/domain/vp2020/cost_accounting/report/umlage_raeumlichkeiten.rb
+++ b/app/domain/vp2020/cost_accounting/report/umlage_raeumlichkeiten.rb
@@ -18,7 +18,8 @@ module Vp2020::CostAccounting
                   tageskurse
                   jahreskurse
                   lufeb
-                  mittelbeschaffung)
+                  mittelbeschaffung
+                  medien_und_publikationen)
 
       FIELDS.each do |field|
         define_method(field) do
@@ -48,7 +49,8 @@ module Vp2020::CostAccounting
           tageskurse.to_d +
           jahreskurse.to_d +
           lufeb.to_d +
-          mittelbeschaffung.to_d
+          mittelbeschaffung.to_d +
+          medien_und_publikationen.to_d
         end
       end
       # rubocop:enable Metrics/AbcSize

--- a/app/domain/vp2020/cost_accounting/report/umlage_verwaltung.rb
+++ b/app/domain/vp2020/cost_accounting/report/umlage_verwaltung.rb
@@ -17,7 +17,8 @@ module Vp2020::CostAccounting
                   tageskurse
                   jahreskurse
                   lufeb
-                  mittelbeschaffung)
+                  mittelbeschaffung
+                  medien_und_publikationen)
 
       FIELDS.each do |field|
         define_method(field) do
@@ -52,7 +53,8 @@ module Vp2020::CostAccounting
           tageskurse.to_d +
           jahreskurse.to_d +
           lufeb.to_d +
-          mittelbeschaffung.to_d
+          mittelbeschaffung.to_d +
+          medien_und_publikationen.to_d
         end
       end
       # rubocop:enable Metrics/AbcSize

--- a/app/domain/vp2020/cost_accounting/report/vollkosten.rb
+++ b/app/domain/vp2020/cost_accounting/report/vollkosten.rb
@@ -27,7 +27,8 @@ module Vp2020::CostAccounting
                               tageskurse
                               jahreskurse
                               lufeb
-                              mittelbeschaffung)
+                              mittelbeschaffung
+                              medien_und_publikationen)
 
       define_summed_field_methods
 

--- a/app/models/time_record.rb
+++ b/app/models/time_record.rb
@@ -74,6 +74,10 @@ class TimeRecord < ActiveRecord::Base
     total_lufeb
   end
 
+  def medien_und_publikationen
+    total_lufeb_media
+  end
+
   def vp_calculations
     @vp_calculations ||= Vertragsperioden::Dispatcher
                          .new(year)


### PR DESCRIPTION
Fixes #56 

Ich musste noch das Feld `total_lufeb_media` verwenden, ich nehme an das wird in #62 bzw. #65 umbenannt da es von LUFEB separiert werden soll.