### PR TITLE
Count all courses

### DIFF
--- a/app/domain/vp2020/course_reporting/client_statistics.rb
+++ b/app/domain/vp2020/course_reporting/client_statistics.rb
@@ -87,12 +87,7 @@ module Vp2020::CourseReporting
       columns << "CASE events.fachkonzept #{fachkonzepte.join(' ')} "\
                  'ELSE events.fachkonzept END AS event_fachkonzept'
 
-      columns << <<~SQL
-        CASE events.type
-        WHEN 'Event::AggregateCourse' THEN SUM(event_course_records.anzahl_kurse)
-        ELSE COUNT(event_course_records.event_id)
-        END AS course_count
-      SQL
+      columns << 'SUM(event_course_records.anzahl_kurse) AS course_count'
 
       columns << <<~SQL.split("\n").map(&:strip).join(' ') # total_tage_teilnehmende
         CASE events.leistungskategorie

--- a/app/domain/vp2020/course_reporting/client_statistics.rb
+++ b/app/domain/vp2020/course_reporting/client_statistics.rb
@@ -67,9 +67,9 @@ module Vp2020::CourseReporting
         end
     end
 
-    def group_canton_participants_relation # rubocop:disable Metrics/MethodLength
+    def group_canton_participants_relation # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
       columns = [
-        'groups.id AS group_id',
+        '`groups`.id AS group_id',
         'events.leistungskategorie AS event_leistungskategorie'
       ]
 
@@ -94,7 +94,7 @@ module Vp2020::CourseReporting
         END AS course_count
       SQL
 
-      columns << <<~SQL.split("\n").join(' ') # total_tage_teilnehmende
+      columns << <<~SQL.split("\n").map(&:strip).join(' ') # total_tage_teilnehmende
         CASE events.leistungskategorie
         WHEN 'tp' THEN SUM(COALESCE(event_course_records.betreuungsstunden, 0))
         ELSE
@@ -105,7 +105,7 @@ module Vp2020::CourseReporting
         END AS course_hours
       SQL
 
-      columns << <<~SQL.split("\n").join(' ')
+      columns << <<~SQL.split("\n").map(&:strip).join(' ')
         CASE events.leistungskategorie
         WHEN 'tp' THEN 0
         ELSE

--- a/app/models/event/course_record.rb
+++ b/app/models/event/course_record.rb
@@ -66,10 +66,9 @@ class Event::CourseRecord < ActiveRecord::Base
   validates :inputkriterien, inclusion: { in: INPUTKRITERIEN }
   validates :kursart, inclusion: { in: KURSARTEN }
   validates :year, inclusion: { in: ->(course_record) { course_record.event.years } }
-  validates :anzahl_kurse, numericality: [
-    { greater_than: 0, if: ->(cr) { cr.event.is_a? Event::AggregateCourse } },
-    { equal: 1,        if: ->(cr) { cr.event.is_a? Event::Course } }
-  ]
+  validates :anzahl_kurse, numericality: { greater_than: 0, if: ->(cr) { cr.event.is_a? Event::AggregateCourse } }
+  validates :anzahl_kurse, numericality: { equal: 1,        if: ->(cr) { cr.event.is_a? Event::Course } }
+
   validates :kursdauer,
             :teilnehmende_behinderte, :teilnehmende_angehoerige, :teilnehmende_weitere,
             :absenzen_behinderte,     :absenzen_angehoerige,     :absenzen_weitere,

--- a/app/models/event/course_record.rb
+++ b/app/models/event/course_record.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2021, insieme Schweiz. This file is part of
+#  Copyright (c) 2012-2022, insieme Schweiz. This file is part of
 #  hitobito_insieme and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_insieme.
@@ -66,7 +66,10 @@ class Event::CourseRecord < ActiveRecord::Base
   validates :inputkriterien, inclusion: { in: INPUTKRITERIEN }
   validates :kursart, inclusion: { in: KURSARTEN }
   validates :year, inclusion: { in: ->(course_record) { course_record.event.years } }
-  validates :anzahl_kurse, numericality: { greater_than: 0 }
+  validates :anzahl_kurse, numericality: [
+    { greater_than: 0, if: ->(cr) { cr.event.is_a? Event::AggregateCourse } },
+    { equal: 1,        if: ->(cr) { cr.event.is_a? Event::Course } }
+  ]
   validates :kursdauer,
             :teilnehmende_behinderte, :teilnehmende_angehoerige, :teilnehmende_weitere,
             :absenzen_behinderte,     :absenzen_angehoerige,     :absenzen_weitere,

--- a/app/models/event/course_record.rb
+++ b/app/models/event/course_record.rb
@@ -66,8 +66,11 @@ class Event::CourseRecord < ActiveRecord::Base
   validates :inputkriterien, inclusion: { in: INPUTKRITERIEN }
   validates :kursart, inclusion: { in: KURSARTEN }
   validates :year, inclusion: { in: ->(course_record) { course_record.event.years } }
-  validates :anzahl_kurse, numericality: { greater_than: 0, if: ->(cr) { cr.event.is_a? Event::AggregateCourse } }
-  validates :anzahl_kurse, numericality: { equal: 1,        if: ->(cr) { cr.event.is_a? Event::Course } }
+
+  validates :anzahl_kurse,
+            numericality: { greater_than: 0, if: ->(cr) { cr.event.is_a? Event::AggregateCourse } }
+  validates :anzahl_kurse,
+            numericality: { equal: 1, if: ->(cr) { cr.event.is_a? Event::Course } }
 
   validates :kursdauer,
             :teilnehmende_behinderte, :teilnehmende_angehoerige, :teilnehmende_weitere,

--- a/app/models/event/course_record.rb
+++ b/app/models/event/course_record.rb
@@ -128,7 +128,7 @@ class Event::CourseRecord < ActiveRecord::Base
     betreuungsstunden
   end
 
-  def set_defaults # rubocop:disable Metrics/CyclomaticComplexity,Metrics/AbcSize
+  def set_defaults
     self.kursart ||= 'weiterbildung'
     self.inputkriterien ||= 'a'
     self.subventioniert ||= true if subventioniert.nil?

--- a/bin/rspec
+++ b/bin/rspec
@@ -3,4 +3,4 @@
 # shellcheck disable=SC2068
 # SC2068: Double quote array expansions to avoid re-splitting elements.
 
-bundle exec spring rspec $@
+bundle exec rspec $@

--- a/spec/models/event/course_record_spec.rb
+++ b/spec/models/event/course_record_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2021, insieme Schweiz. This file is part of
+#  Copyright (c) 2012-2022, insieme Schweiz. This file is part of
 #  hitobito_insieme and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_insieme.
@@ -184,6 +184,33 @@ describe Event::CourseRecord do
       event_bk.update(leistungskategorie: nil)
       expect(new_record(event_bk, inputkriterien: 'a', kursart: 'freizeit_und_sport')).to be_valid
       expect(new_record(event_bk, inputkriterien: 'c', kursart: 'freizeit_und_sport')).to be_valid
+    end
+
+    it 'requires and enforces anzahl_kurse to be 1 for courses' do
+      course_record = new_record(event_bk, anzahl_kurse: 1)
+
+      expect(course_record.anzahl_kurse).to eq 1
+      expect(course_record).to be_valid
+
+      course_record.anzahl_kurse = 2
+      expect do
+        expect(course_record).to be_valid
+      end.to change(course_record, :anzahl_kurse).from(2).to(1)
+    end
+
+    it 'allows anzahl_kurse to be more than 1 for aggregate_courses' do
+      course_record = new_record(aggregate_bk, anzahl_kurse: 1)
+
+      expect(course_record.anzahl_kurse).to eq 1
+      expect(course_record).to be_valid
+
+      course_record.anzahl_kurse = 2
+      expect do
+        expect(course_record).to be_valid
+      end.to_not change(course_record, :anzahl_kurse)
+
+      course_record.anzahl_kurse = -23
+      expect(course_record).to_not be_valid
     end
   end
 


### PR DESCRIPTION
Fixes #99

The client-statistics are calculated mostly through one big query. It was requested to be separate from the other calculations. The query copied the domain-code that is present in other locations. The conditional how to count the courses does not translate to SQL well, but it turns out it does not have to.

MySQL just took one approach, depending on which branch of the case-statement was true first for the aggregated rows. Therefore, it sometimes counted correctly and sometimes did not. The error (column type is not part of grouping) was only visible when talking directly to the database.

The solution was to use the same column for all event-types. A validation to ensure the feasibility of this field has been expanded.