### PR TITLE
IV Finanzierungsgrad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 
 *  Export "Kennzahlen pro Verein" um Sozialberatung erweitert (insieme#104)
+*  Anzeige des "IV Finanzierungsgrad" auf der Kapitalsubstratseite (insieme#105)
 
 ## Version 1.26
 

--- a/app/domain/vp2020/time_record/report/capital_substrate.rb
+++ b/app/domain/vp2020/time_record/report/capital_substrate.rb
@@ -52,17 +52,17 @@ module Vp2020
       deckungsbeitrag4_sum
     end
 
-    # def iv_finanzierungsgrad_vp2015
-    #   iv_finanzierungsgrad_period(2015, 2019).to_d
-    # end
+    def iv_finanzierungsgrad_vp2015
+      iv_finanzierungsgrad_period(2015, 2019).to_d
+    end
 
-    # def iv_finanzierungsgrad_vp2020
-    #   iv_finanzierungsgrad_period(2020, table.year).to_d
-    # end
+    def iv_finanzierungsgrad_vp2020
+      iv_finanzierungsgrad_period(2020, table.year).to_d
+    end
 
-    # def iv_finanzierungsgrad_current
-    #   iv_finanzierungsgrad_period(table.year, table.year).to_d
-    # end
+    def iv_finanzierungsgrad_current
+      iv_finanzierungsgrad_period(table.year, table.year).to_d
+    end
 
     def exemption
       globals ? - globals.capital_substrate_exemption.to_d : 0
@@ -87,19 +87,19 @@ module Vp2020
       end
     end
 
-    # def iv_finanzierungsgrad_period(start, finish)
-    #   gesamtkosten = (start..finish).sum do |y|
-    #     time_record_table(y).cost_accounting_value_of('total_aufwand', 'aufwand_ertrag_ko_re').to_d
-    #   end
+    def iv_finanzierungsgrad_period(start, finish)
+      gesamtkosten = (start..finish).sum do |y|
+        time_record_table(y).cost_accounting_value_of('total_aufwand', 'aufwand_ertrag_ko_re').to_d
+      end
 
-    #   return 0 if gesamtkosten.zero?
+      return 0 if gesamtkosten.zero?
 
-    #   total_iv_beitrag = (start..finish).sum do |y|
-    #     time_record_table(y).cost_accounting_value_of('beitraege_iv', 'aufwand_ertrag_fibu').to_d
-    #   end
+      total_iv_beitrag = (start..finish).sum do |y|
+        time_record_table(y).cost_accounting_value_of('beitraege_iv', 'aufwand_ertrag_fibu').to_d
+      end
 
-    #   total_iv_beitrag * 100 / gesamtkosten
-    # end
+      total_iv_beitrag / gesamtkosten
+    end
 
     def time_record_table(year)
       @time_record_tables[year] ||= vp_class('TimeRecord::Table').new(table.group, year)

--- a/app/domain/vp2020/time_record/report/capital_substrate.rb
+++ b/app/domain/vp2020/time_record/report/capital_substrate.rb
@@ -52,6 +52,18 @@ module Vp2020
       deckungsbeitrag4_sum
     end
 
+    # def iv_finanzierungsgrad_vp2015
+    #   iv_finanzierungsgrad_period(2015, 2019).to_d
+    # end
+
+    # def iv_finanzierungsgrad_vp2020
+    #   iv_finanzierungsgrad_period(2020, table.year).to_d
+    # end
+
+    # def iv_finanzierungsgrad_current
+    #   iv_finanzierungsgrad_period(table.year, table.year).to_d
+    # end
+
     def exemption
       globals ? - globals.capital_substrate_exemption.to_d : 0
     end
@@ -74,6 +86,20 @@ module Vp2020
         time_record_table(y).cost_accounting_value_of('deckungsbeitrag4', 'total').to_d
       end
     end
+
+    # def iv_finanzierungsgrad_period(start, finish)
+    #   gesamtkosten = (start..finish).sum do |y|
+    #     time_record_table(y).cost_accounting_value_of('total_aufwand', 'aufwand_ertrag_ko_re').to_d
+    #   end
+
+    #   return 0 if gesamtkosten.zero?
+
+    #   total_iv_beitrag = (start..finish).sum do |y|
+    #     time_record_table(y).cost_accounting_value_of('beitraege_iv', 'aufwand_ertrag_fibu').to_d
+    #   end
+
+    #   total_iv_beitrag * 100 / gesamtkosten
+    # end
 
     def time_record_table(year)
       @time_record_tables[year] ||= vp_class('TimeRecord::Table').new(table.group, year)

--- a/app/views/vp2020/capital_substrate/edit.html.haml
+++ b/app/views/vp2020/capital_substrate/edit.html.haml
@@ -30,7 +30,7 @@
     = f.labeled_readonly_value :exemption, value: format_money(report.exemption)
     = f.labeled_readonly_value :capital_substrate_allocated, value: format_money(report.capital_substrate_allocated)
 
-  -# = field_set_tag do
-  -#   = f.labeled_readonly_value :iv_finanzierungsgrad_vp2015,  value: format_percent(report.iv_finanzierungsgrad_vp2015)
-  -#   = f.labeled_readonly_value :iv_finanzierungsgrad_vp2020,  value: format_percent(report.iv_finanzierungsgrad_vp2020)
-  -#   = f.labeled_readonly_value :iv_finanzierungsgrad_current, value: format_percent(report.iv_finanzierungsgrad_current)
+  = field_set_tag do
+    = f.labeled_readonly_value :iv_finanzierungsgrad_vp2015,  value: format_percent(report.iv_finanzierungsgrad_vp2015 * 100)
+    = f.labeled_readonly_value :iv_finanzierungsgrad_vp2020,  value: format_percent(report.iv_finanzierungsgrad_vp2020 * 100)
+    = f.labeled_readonly_value :iv_finanzierungsgrad_current, value: format_percent(report.iv_finanzierungsgrad_current * 100)

--- a/app/views/vp2020/capital_substrate/edit.html.haml
+++ b/app/views/vp2020/capital_substrate/edit.html.haml
@@ -29,3 +29,8 @@
   = field_set_tag do
     = f.labeled_readonly_value :exemption, value: format_money(report.exemption)
     = f.labeled_readonly_value :capital_substrate_allocated, value: format_money(report.capital_substrate_allocated)
+
+  -# = field_set_tag do
+  -#   = f.labeled_readonly_value :iv_finanzierungsgrad_vp2015,  value: format_percent(report.iv_finanzierungsgrad_vp2015)
+  -#   = f.labeled_readonly_value :iv_finanzierungsgrad_vp2020,  value: format_percent(report.iv_finanzierungsgrad_vp2020)
+  -#   = f.labeled_readonly_value :iv_finanzierungsgrad_current, value: format_percent(report.iv_finanzierungsgrad_current)

--- a/config/locales/models.insieme.de.yml
+++ b/config/locales/models.insieme.de.yml
@@ -734,6 +734,9 @@ de:
         deckungsbeitrag4_vp2015: Summe der DB4 von 2015-2019
         deckungsbeitrag4_vp2020: Summe der DB4 der Vertragsperiode 2020-2023
         deckungsbeitrag4_sum: Summe der DB4 von 2015 bis %{year}
+        iv_finanzierungsgrad_vp2015: IV Finanzierungsgrad 2015 - 2019
+        iv_finanzierungsgrad_vp2020: IV Finanzierungsgrad 2020 - 2023
+        iv_finanzierungsgrad_current: aktueller IV Finanzierungsgrad
 
     errors:
       models:


### PR DESCRIPTION
Fixes #105

Die Specs lesen sich etwas komisch... Die Abschreibungen werden nachher ein Teil der Kosten "Total Aufwand", daher habe ich diese verwendet. Die Abgrenzung FiBu wird abgezogen, daher habe ich dort für Rechnungen in 2020 die schon existenten Kosten eingetragen. So liest sich die Spec einigermaßen verständlich. Ich bin da für Verbesserungsvorschläge (Kommentare, Auslagerung von "magischen Zahlen" in sprechend benannte Variablen, ...) offen.

Vorerst erscheint es mir aber gut genug.