### PR TITLE
Add labels to addresses, new labels for email/phone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Hitobito Insieme Changelog
 
+## unreleased
+
+*  Adjust insieme specific labels for addresses and contactables
+
 ## Version 1.27
 
 *  Export "Kennzahlen pro Verein" um Sozialberatung erweitert (hitobito_insieme#104)

--- a/app/controllers/insieme/people_controller.rb
+++ b/app/controllers/insieme/people_controller.rb
@@ -15,7 +15,8 @@ module Insieme
          :disabled_person_last_name, :disabled_person_address,
          :disabled_person_zip_town, :disabled_person_zip_code,
          :disabled_person_town, :disabled_person_birthday,
-         :newly_registered]
+         :newly_registered, :correspondence_general_label, :billing_general_label,
+         :correspondence_course_label, :billing_course_label]
 
       # Permit person address fields
       Person::ADDRESS_TYPES.each do |prefix|

--- a/app/helpers/contactable_insieme_helper.rb
+++ b/app/helpers/contactable_insieme_helper.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2022, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module ContactableInsiemeHelper
+  def additional_email_label_select(additional_email_form)
+    additional_email = additional_email_form.object
+    current_label = additional_email.label
+    options = (additional_email.class.predefined_labels | [current_label].compact).map do |value|
+      translated = additional_email.class.translate_label(value)
+      OpenStruct.new(value: value, translated: translated)
+    end
+    additional_email_form.collection_select(:translated_label, options, :value, :translated, {}, class: 'span2')
+  end
+end

--- a/app/helpers/people_insieme_helper.rb
+++ b/app/helpers/people_insieme_helper.rb
@@ -37,4 +37,13 @@ module PeopleInsiemeHelper
            locals: { entry: person })
   end
 
+  def address_label_select(person_form, label_attribute_prefix)
+    person = person_form.object
+    current_label = person.send("#{label_attribute_prefix}_label")
+    options = (Settings.addresses.predefined_labels | [current_label].compact).map do |value|
+      translated = I18n.t("activerecord.attributes.person.address_labels.#{value}", default: value)
+      OpenStruct.new(value: value, translated: translated)
+    end
+    person_form.collection_select("#{label_attribute_prefix}_label", options, :value, :translated, include_blank: true)
+  end
 end

--- a/app/views/contactable/_additional_email_fields.html.haml
+++ b/app/views/contactable/_additional_email_fields.html.haml
@@ -1,0 +1,18 @@
+-#  Copyright (c) 2012-2022, insieme Schweiz. This file is part of
+-#  hitobito_insieme and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito_insieme.
+
+= f.input_field(:email,
+                class: 'span4',
+                placeholder: t('.placeholder_value'))
+= additional_email_label_select(f)
+
+- if entry.is_a?(Person)
+  = f.label(:mailings, class: 'checkbox span2') do
+    = f.check_box(:mailings)
+    %span{rel: 'tooltip', title: t('.tooltip_mailings')}
+      = t(:"activerecord.attributes.additional_emails.mailings")
+      %i.icon.icon-info-sign
+
+= render 'contactable/public_check_box', f: f

--- a/app/views/contactable/_single_address_fields.html.haml
+++ b/app/views/contactable/_single_address_fields.html.haml
@@ -13,6 +13,8 @@
                             data: { hide: "person_#{prefix}" })
 
   = toggled_address_fields(prefix, f.object) do
+    - if f.object.respond_to?("#{prefix}_label")
+      = f.labeled("#{prefix}_label", address_label_select(f, prefix))
     = f.labeled_input_field(:"#{prefix}_salutation", label: t('activerecord.attributes.person.salutation'))
     = f.labeled_input_field(:"#{prefix}_first_name", label: t('activerecord.attributes.person.first_name'))
     = f.labeled_input_field(:"#{prefix}_last_name", label: t('activerecord.attributes.person.last_name'))

--- a/config/locales/models.insieme.de.yml
+++ b/config/locales/models.insieme.de.yml
@@ -583,6 +583,16 @@ de:
         dossier: Dossierlink
         ahv_number: AHV Nummer
 
+        address_labels:
+          Privat: Privat
+          Arbeit: Arbeit
+          Vater: Vater
+          Mutter: Mutter
+          Beistand: Beistand
+          Wohngruppe: Wohngruppe
+          Wohnheim: Wohnheim
+          Andere: Andere
+
         correspondence_general_salutation: Anrede Korrespondenzadresse allgemein
         correspondence_general_first_name: Vorname Korrespondenzadresse allgemein
         correspondence_general_last_name: Nachname Korrespondenzadresse allgemein
@@ -593,6 +603,7 @@ de:
         correspondence_general_town: Ort Korrespondenzadresse allgemein
         correspondence_general_country: Land Korrespondenzadresse allgemein
         correspondence_general_same_as_main: Korrespondenzadresse allgemein gleich Hauptadresse
+        correspondence_general_label: Label
 
         billing_general_salutation: Anrede Rechnungsadresse allgemein
         billing_general_first_name: Vorname Rechnungsadresse allgemein
@@ -604,6 +615,7 @@ de:
         billing_general_town: Ort Rechnungsadresse allgemein
         billing_general_country: Land Rechnungsadresse allgemein
         billing_general_same_as_main: Rechnungsadresse allgemein gleich Hauptadresse
+        billing_general_label: Label
 
         correspondence_course_salutation: Anrede Korrespondenzadresse Kurs
         correspondence_course_first_name: Vorname Korrespondenzadresse Kurs
@@ -615,6 +627,7 @@ de:
         correspondence_course_town: Ort Korrespondenzadresse Kurs
         correspondence_course_country: Land Korrespondenzadresse Kurs
         correspondence_course_same_as_main: Korrespondenzadresse Kurs gleich Hauptadresse
+        correspondence_course_label: Label
 
         billing_course_salutation: Anrede Rechnungsadresse Kurs
         billing_course_first_name: Vorname Rechnungsadresse Kurs
@@ -626,6 +639,7 @@ de:
         billing_course_town: Ort Rechnungsadresse Kurs
         billing_course_country: Land Rechnungsadresse Kurs
         billing_course_same_as_main: Rechnungsadresse Kurs gleich Hauptadresse
+        billing_course_label: Label
 
       reporting_parameter:
         year: Jahr

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -30,3 +30,34 @@ sphinx:
 groups:
   statistics:
     enabled: false
+
+.common_contact_labels: &common_contact_labels
+  - "--"
+  - Privat
+  - Arbeit
+  - Vater
+  - Mutter
+  - Beistand
+  - Wohngruppe
+  - Wohnheim
+  - Andere
+
+additional_email:
+  predefined_labels: *common_contact_labels
+
+addresses:
+  predefined_labels: *common_contact_labels
+
+phone_number:
+  predefined_labels:
+    - --
+    - Privat
+    - Mobil
+    - Arbeit
+    - Vater
+    - Mutter
+    - Beistand
+    - Wohngruppe
+    - Wohnheim
+    - Fax
+    - Andere

--- a/db/migrate/20221124094837_add_address_labels_to_people.rb
+++ b/db/migrate/20221124094837_add_address_labels_to_people.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2022, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+class AddAddressLabelsToPeople < ActiveRecord::Migration[6.1]
+  ADDRESS_TYPES = %w(correspondence_general
+                     billing_general
+                     correspondence_course
+                     billing_course).freeze
+  def change
+    ADDRESS_TYPES.each do |concern|
+      add_column :people, "#{concern}_label", :string
+    end
+  end
+end

--- a/spec/helpers/contactable_insieme_helper_spec.rb
+++ b/spec/helpers/contactable_insieme_helper_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2022, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require 'spec_helper'
+
+describe ContactableInsiemeHelper, type: :helper do
+  describe '#additional_email_label_select' do
+    let(:additional_email) { people(:top_leader).additional_emails.build(email: 'other@example.com') }
+    let(:form) { StandardFormBuilder.new(:additional_email, additional_email, self, {}) }
+
+    standard_options = AdditionalEmail.predefined_labels
+
+    def available_options(html_string)
+      Capybara.string(html_string).all(:option).map(&:value)
+    end
+
+    it 'has the expected options' do
+      result = helper.additional_email_label_select(form)
+      expect(result).to have_selector("select[name='additional_email[translated_label]']")
+
+      expect(available_options(result)).to match_array standard_options
+    end
+
+    it 'the current value is selected' do
+      additional_email.label = standard_options.third
+      result = helper.additional_email_label_select(form)
+
+      expect(result).to have_selector("option[value='#{standard_options.third}'][selected='selected']")
+    end
+
+    it 'includes current value as option' do
+      additional_email.label = 'nonstandard_value'
+      result = helper.additional_email_label_select(form)
+
+      expect(available_options(result)).to match_array [*standard_options, 'nonstandard_value']
+    end
+
+    it 'the nonstandard value is selected' do
+      additional_email.label = 'nonstandard_value'
+      result = helper.additional_email_label_select(form)
+
+      expect(result).to have_selector("option[value='nonstandard_value'][selected='selected']")
+    end
+  end
+end

--- a/spec/helpers/people_insieme_helper_spec.rb
+++ b/spec/helpers/people_insieme_helper_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2022, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require 'spec_helper'
+
+describe PeopleInsiemeHelper, type: :helper do
+  let(:person) { people(:top_leader) }
+
+  describe '#address_label_select' do
+    let(:form) { StandardFormBuilder.new(:person, person, self, {}) }
+
+    expected_options = Settings.addresses.predefined_labels + ['']
+
+    %w(correspondence_general correspondence_course billing_general billing_course).each do |address_type|
+      context "with prefix=#{address_type}" do
+        def available_options(html_string)
+          Capybara.string(html_string).all(:option).map(&:value)
+        end
+
+        it 'has the expected options' do
+          result = helper.address_label_select(form, address_type)
+          expect(result).to have_selector("select[name='person[#{address_type}_label]']")
+
+          expect(available_options(result)).to match_array expected_options
+        end
+
+        it 'the current value is selected' do
+          person.send("#{address_type}_label=", expected_options.third)
+          result = helper.address_label_select(form, address_type)
+
+          expect(result).to have_selector("option[value='#{expected_options.third}'][selected='selected']")
+        end
+
+        it 'includes current value as option' do
+          person.send("#{address_type}_label=", 'nonstandard_value')
+          result = helper.address_label_select(form, address_type)
+
+          expect(available_options(result)).to match_array [*expected_options, 'nonstandard_value']
+        end
+
+        it 'the nonstandard value is selected' do
+          person.send("#{address_type}_label=", 'nonstandard_value')
+          result = helper.address_label_select(form, address_type)
+
+          expect(result).to have_selector("option[value='nonstandard_value'][selected='selected']")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Das Email Label wird nun im Formular als select tag dargestellt statt einem Freitext Feld. Der Benutzer muss von einem vordefinierten Wert auswählen.
Für bestehende records mit einem Email Label welches nicht in der Liste der vordefinierten Werte enthalten ist, wird der aktuelle Wert als zusätzliche Option angezeigt. So sind die betroffenen records mit der neuen Label Logik kompatibel.

Refs: #124