### PR TITLE
Anpassungen FTE

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,3 +26,7 @@ Naming/MethodParameterName:
     # - os
     # - pp
     # - to
+
+Naming/VariableNumber:
+  AllowedPatterns:
+    - .*paragraph_74.*

--- a/app/domain/fp2020/time_record/calculation.rb
+++ b/app/domain/fp2020/time_record/calculation.rb
@@ -101,7 +101,7 @@ module Fp2020
     end
 
     def total_paragraph_74
-      @total_paragraph_74 ||= # rubocop:disable Naming/VariableNumber
+      @total_paragraph_74 ||=
         total_lufeb.to_i +
         total_media.to_i +
         total_courses.to_i +

--- a/app/domain/fp2022/time_record/calculation.rb
+++ b/app/domain/fp2022/time_record/calculation.rb
@@ -103,7 +103,7 @@ module Fp2022
     end
 
     def total_paragraph_74
-      @total_paragraph_74 ||= # rubocop:disable Naming/VariableNumber
+      @total_paragraph_74 ||=
         total_lufeb.to_i +
         total_media.to_i +
         total_courses.to_i +

--- a/app/domain/fp2022/time_record/report/employee_time.rb
+++ b/app/domain/fp2022/time_record/report/employee_time.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2022, insieme Schweiz. This file is part of
+#  Copyright (c) 2012-2023, insieme Schweiz. This file is part of
 #  hitobito_insieme and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_insieme.
@@ -9,7 +9,7 @@ module Fp2022
   class TimeRecord::Report::EmployeeTime < TimeRecord::Report::Base
 
     def paragraph_74
-      record.total_paragraph_74_pensum - honorar_pensum('aufwand_ertrag_fibu').to_d
+      record.total_paragraph_74_pensum
     end
 
     def not_paragraph_74
@@ -17,18 +17,8 @@ module Fp2022
     end
 
     def total
-      record.total_pensum - honorar_pensum('total').to_d
+      record.total_pensum
     end
 
-    private
-
-    def honorar_pensum(key)
-      honorar_costs = table.cost_accounting_value_of('honorare', key).to_d
-
-      price = record.fp_calculations.class::ASSUMED_HOURLY_RATE
-      hours = record.fp_calculations.send(:bsv_hours_per_year)
-
-      honorar_costs / (price * hours)
-    end
   end
 end

--- a/spec/domain/fp2022/time_record/report/employee_time_spec.rb
+++ b/spec/domain/fp2022/time_record/report/employee_time_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2022, Insieme Schweiz. This file is part of
+#  Copyright (c) 2022-2023, Insieme Schweiz. This file is part of
 #  hitobito_insieme and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_insieme.
@@ -24,7 +24,7 @@ describe Fp2022::TimeRecord::Report::EmployeeTime do
 
   context '#paragraph_74' do
     it 'calculates the correct value' do
-      expect(report.paragraph_74).to eq ( 3.to_d - 1.to_d ) # 2
+      expect(report.paragraph_74).to eq 3.to_d
     end
   end
 
@@ -36,7 +36,7 @@ describe Fp2022::TimeRecord::Report::EmployeeTime do
 
   context '#total' do
     it 'calculates the correct value' do
-      expect(report.total).to eq ( 3.to_d + 5.to_d - 2.to_d ) # 6
+      expect(report.total).to eq ( 3.to_d + 5.to_d ) # 8
     end
   end
 


### PR DESCRIPTION
Das "Herausrechnen" der Honorarkräfte ist nun wieder entfernt.

Die Warteliste ist für Kurse aktiv. Dies kann und muss pro Kurs eingestellt werden. Wenn Teilnehmerlimit und Warteliste beides aktiviert sind, werden Anmeldungen nach soweit möglich direkt zu Teilnehmern. Darüber hinaus gehende Anmeldungen landen dann auf der Warteliste.

Die Meldung ist im transifex auf Deutsch und Französisch verfügbar.

Fixes hitobito/hitobito#2019