### PR TITLE
Personen löschen können

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Hitobito Insieme Changelog
 
+## unreleased
+
+*  Möglichkeit, Personen ohne Rollen zu löschen an einige Rollen vergeben (hitobito_insieme#151)
+
 ## Version 1.28
 
 *  Adjust insieme specific labels for addresses and contactables

--- a/app/abilities/insieme/group_ability.rb
+++ b/app/abilities/insieme/group_ability.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2014, insieme Schweiz. This file is part of
+#  Copyright (c) 2012-2024, insieme Schweiz. This file is part of
 #  hitobito_insieme and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_insieme.
@@ -67,6 +67,10 @@ module Insieme::GroupAbility
       permission(:layer_read).may(:statistics).in_same_group
       permission(:layer_and_below_read).may(:statistics).in_same_group
 
+      permission(:manual_deletion)
+        .may(:manually_delete_people)
+        .if_permission_in_layer_and_manual_deletion_enabled
+
       permission(:any).may(:controlling).if_dachverein_reporting
 
       general(:reporting).for_reporting_group
@@ -74,6 +78,10 @@ module Insieme::GroupAbility
       general(:controlling).for_dachverein
 
     end
+  end
+
+  def if_permission_in_layer_and_manual_deletion_enabled
+    FeatureGate.enabled?('people.manual_deletion') && if_permission_in_layer
   end
 
   def if_dachverein_reporting_or_regionalverein_reporting_in_same_group

--- a/app/abilities/insieme/group_ability.rb
+++ b/app/abilities/insieme/group_ability.rb
@@ -21,10 +21,10 @@ module Insieme::GroupAbility
                            Group::ExterneOrganisation::Geschaeftsfuehrung,
                            Group::ExterneOrganisation::Sekretariat,
                            Group::ExterneOrganisation::Adressverwaltung,
-                           Group::ExterneOrganisation::Controlling]
+                           Group::ExterneOrganisation::Controlling].freeze
 
-  included do
-    on(Group) do
+  included do # rubocop:disable Metrics/BlockLength
+    on(Group) do # rubocop:disable Metrics/BlockLength
       permission(:any).
         may(:read).
         any_role_in_same_layer_or_layer_group_or_if_dachverein_manager
@@ -123,8 +123,8 @@ module Insieme::GroupAbility
 
   def contact_data_in_same_layer
     group &&
-    user_context.layer_ids(user.groups_with_permission(:contact_data)).
-                 include?(group.layer_group_id)
+    user_context.layer_ids(user.groups_with_permission(:contact_data))
+                .include?(group.layer_group_id)
   end
 
   def if_group_in_hierarchy

--- a/app/models/group/externe_organisation.rb
+++ b/app/models/group/externe_organisation.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2022, insieme Schweiz. This file is part of
+#  Copyright (c) 2012-2024, insieme Schweiz. This file is part of
 #  hitobito_insieme and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_insieme.
@@ -63,17 +63,17 @@ class Group::ExterneOrganisation < Group
   end
 
   class Geschaeftsfuehrung < ::Role
-    self.permissions = [:layer_full, :contact_data]
+    self.permissions = [:layer_full, :contact_data, :manual_deletion]
     self.two_factor_authentication_enforced = true
   end
 
   class Sekretariat < ::Role
-    self.permissions = [:layer_full, :contact_data]
+    self.permissions = [:layer_full, :contact_data, :manual_deletion]
     self.two_factor_authentication_enforced = true
   end
 
   class Adressverwaltung < ::Role
-    self.permissions = [:layer_full, :contact_data]
+    self.permissions = [:layer_full, :contact_data, :manual_deletion]
     self.two_factor_authentication_enforced = true
   end
 

--- a/app/models/group/externe_organisation.rb
+++ b/app/models/group/externe_organisation.rb
@@ -97,7 +97,6 @@ class Group::ExterneOrganisation < Group
     self.two_factor_authentication_enforced = true
   end
 
-
   class External < ::Role
     self.permissions = []
     self.visible_from_above = false

--- a/app/models/group/regionalverein.rb
+++ b/app/models/group/regionalverein.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2022, insieme Schweiz. This file is part of
+#  Copyright (c) 2012-2024, insieme Schweiz. This file is part of
 #  hitobito_insieme and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_insieme.
@@ -63,17 +63,17 @@ class Group::Regionalverein < Group
   end
 
   class Geschaeftsfuehrung < ::Role
-    self.permissions = [:layer_full, :contact_data]
+    self.permissions = [:layer_full, :contact_data, :manual_deletion]
     self.two_factor_authentication_enforced = true
   end
 
   class Sekretariat < ::Role
-    self.permissions = [:layer_full, :contact_data]
+    self.permissions = [:layer_full, :contact_data, :manual_deletion]
     self.two_factor_authentication_enforced = true
   end
 
   class Adressverwaltung < ::Role
-    self.permissions = [:layer_full, :contact_data]
+    self.permissions = [:layer_full, :contact_data, :manual_deletion]
     self.two_factor_authentication_enforced = true
   end
 

--- a/app/models/group/regionalverein.rb
+++ b/app/models/group/regionalverein.rb
@@ -97,7 +97,6 @@ class Group::Regionalverein < Group
     self.two_factor_authentication_enforced = true
   end
 
-
   class External < ::Role
     self.permissions = []
     self.visible_from_above = false

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,4 @@
-#  Copyright (c) 2012-2014, insieme Schweiz. This file is part of
+#  Copyright (c) 2012-2024, insieme Schweiz. This file is part of
 #  hitobito_insieme and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_insieme.
@@ -29,6 +29,12 @@ sphinx:
 
 groups:
   statistics:
+    enabled: false
+
+people:
+  manual_deletion:
+    enabled: true
+  cleanup_job:
     enabled: false
 
 .common_contact_labels: &common_contact_labels

--- a/lib/hitobito_insieme/wagon.rb
+++ b/lib/hitobito_insieme/wagon.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2021, insieme Schweiz. This file is part of
+#  Copyright (c) 2012-2024, insieme Schweiz. This file is part of
 #  hitobito_insieme and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_insieme.
@@ -39,6 +39,11 @@ module HitobitoInsieme
       # serializers
       PersonSerializer.include Insieme::PersonSerializer
       GroupSerializer.include Insieme::GroupSerializer
+
+      # permissions
+      Role::Permissions << :manual_deletion
+      AbilityDsl::UserContext::GROUP_PERMISSIONS << :manual_deletion
+      AbilityDsl::UserContext::LAYER_PERMISSIONS << :manual_deletion
 
       # abilities
       GroupAbility.include Insieme::GroupAbility

--- a/spec/abilities/group_ability_spec.rb
+++ b/spec/abilities/group_ability_spec.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-#  Copyright (c) 2012-2014, insieme Schweiz. This file is part of
+#  Copyright (c) 2012-2024, insieme Schweiz. This file is part of
 #  hitobito_insieme and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_insieme.
@@ -230,6 +230,14 @@ describe GroupAbility do
       it 'may not view deleted subgroups in layer below' do
         is_expected.not_to be_able_to(:deleted_subgroups, groups(:seeland))
       end
+
+      it 'may manually delete people' do
+        is_expected.to be_able_to(:manually_delete_people, group)
+      end
+
+      it 'may not manually delete people in layer below' do
+        is_expected.not_to be_able_to(:manually_delete_people, groups(:seeland))
+      end
     end
 
     context Group::Regionalverein::Controlling do
@@ -364,9 +372,14 @@ describe GroupAbility do
       it 'may destroy subgroups in own layer' do
         is_expected.to be_able_to(:destroy, subgroup)
       end
+
+      it 'may manually delete people in own group' do
+        is_expected.to be_able_to(:manually_delete_people, group)
+      end
+
+      it 'may not manually delete people in another layer' do
+        is_expected.not_to be_able_to(:manually_delete_people, Group::ExterneOrganisation.new(parent: groups(:dachverein)))
+      end
     end
   end
-
-
-
 end


### PR DESCRIPTION
Dieser PR führt primär eine neue Permission `:manual_deletion` ein, um die bestehenden Rechte der geänderten Rollen nicht fälschlicherweise zu erweitern. Da die Externen Organisationen am Dachverband hängen können, wäre `:layer_and_below_full` definitiv eine falsche Rechteausweitung.

fixes #151 