### PR TITLE
Reporting: neue fp2024 für BSV-Vertragsperiode 2024-2027 (Issue#204)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 2.8
 
+* fp2024 für neue BSV-Vertragsperiode 2024-2027 hinzugefügt (hitobito_insieme#204)
 * Gruppen ID wird als Insieme-ID auf der Gruppenseite angezeigt (hitobito_insieme#189)
 * AHV Nummern wurden den Personen entfernt (hitobito_insieme#192)
 * Neue Rollen wurden hinzugefügt und Berechtigungen von bestehenden Rollen angepasst (hitobito_insieme#188)

--- a/app/domain/featureperioden/dispatcher.rb
+++ b/app/domain/featureperioden/dispatcher.rb
@@ -7,7 +7,7 @@
 
 module Featureperioden
   class Dispatcher
-    KNOWN_BASE_YEARS = [2015, 2020, 2022].freeze
+    KNOWN_BASE_YEARS = [2015, 2020, 2022, 2024].freeze
 
     def self.domain_classes(class_name)
       KNOWN_BASE_YEARS.map { |fp| Dispatcher.new(fp).domain_class(class_name) }

--- a/app/domain/fp2024/cost_accounting/aggregation.rb
+++ b/app/domain/fp2024/cost_accounting/aggregation.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2020, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  class Aggregation
+    attr_reader :year
+
+    def initialize(year)
+      @year = year
+      build_tables
+    end
+
+    def value_of(report, field)
+      values = @tables.values.collect { |t| t.value_of(report, field) }
+      if values.compact.present?
+        values.sum(&:to_d)
+      end
+    end
+
+    def reports
+      @reports ||= Table::REPORTS.each_with_object({}) do |report, hash|
+        hash[report.key] = Report.new(report.key, report.kontengruppe, self)
+      end
+    end
+
+    def table(group)
+      @tables[group]
+    end
+
+    private
+
+    def build_tables
+      groups = (time_records.keys + cost_records.keys).uniq
+      @tables = groups.index_with do |group|
+        Table.new(group, year).tap do |t|
+          t.set_records(time_records[group], cost_records[group], course_costs[group.id])
+        end
+      end
+    end
+
+    def time_records
+      @time_records ||= TimeRecord::EmployeeTime
+        .where(year: year).includes(:group)
+        .index_by(&:group)
+    end
+
+    def cost_records
+      @cost_records ||=
+        Hash.new { |h, k| h[k] = {} }.tap do |hash|
+          records = CostAccountingRecord.where(year: year).calculation_fields.includes(:group)
+          records.each { |r| hash[r.group][r.report] = r }
+        end
+    end
+
+    def course_costs
+      @course_costs ||=
+        Hash.new { |h1, k1| h1[k1] = Hash.new { |h2, k2| h2[k2] = {} } }.tap do |hash|
+          load_course_costs.each do |group_id, lk, honorare, unterkunft, uebriges|
+            hash[group_id][lk] = {"honorare" => honorare,
+                                   "raumaufwand" => unterkunft,
+                                   "uebriger_sachaufwand" => uebriges}
+          end
+        end
+    end
+
+    def load_course_costs
+      Event::CourseRecord
+        .joins(event: :groups)
+        .group("groups.id, events.leistungskategorie")
+        .where(year: year, subventioniert: true)
+        .pluck("groups.id AS group_id, leistungskategorie, " \
+              "SUM(honorare_inkl_sozialversicherung), SUM(unterkunft), SUM(uebriges)")
+    end
+
+    class Report
+      include Featureperioden::Domain
+
+      attr_reader :key, :kontengruppe, :aggregation
+      delegate :year, to: :aggregation
+
+      def initialize(key, kontengruppe, aggregation)
+        @key = key
+        @kontengruppe = kontengruppe
+        @aggregation = aggregation
+      end
+
+      Table.fields.each do |field|
+        define_method(field) do
+          @aggregation.value_of(key, field)
+        end
+      end
+
+      def short_name
+        I18n.t("report.#{key}.short_name",
+          scope: fp_i18n_scope("cost_accounting"),
+          default: I18n.t("cost_accounting.report.#{key}.short_name"))
+      end
+
+      def human_name
+        I18n.t("report.#{key}.name",
+          scope: fp_i18n_scope("cost_accounting"),
+          default: I18n.t("cost_accounting.report.#{key}.name"))
+      end
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/pro_verein.rb
+++ b/app/domain/fp2024/cost_accounting/pro_verein.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2021, Insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  class ProVerein
+    include Featureperioden::Domain
+
+    attr_reader :year
+
+    def initialize(year)
+      @year = year
+      @data_for = {}
+    end
+
+    def vereine
+      @vereine ||= Group.by_bsv_number.all
+    end
+
+    def data_for(verein)
+      @data_for[verein.id] ||= fetch_data_for(verein)
+    end
+
+    CostAccountingRow = Struct.new(
+      :aufwand_ertrag_fibu, :abgrenzung, :gemeinkosten, :sozialberatung, :media,
+      :jahreskurse, :blockkurse, :tageskurse, :treffpunkte, :lufeb
+    ) do
+      def self.empty_row
+        new(*Array.new(10, nil))
+      end
+
+      def members
+        [:aufwand_ertrag_fibu, :abgrenzung, :klr, :gemeinkosten, :sozialberatung,
+          :bauberatung, :rechtsberatung, :vermittlung, :wohnbegleitung, :media,
+          :jahreskurse, :blockkurse, :tageskurse, :treffpunkte, :lufeb]
+      end
+
+      def +(other)
+        values = to_a.zip(other.to_a).map do |self_value, other_value|
+          self_value + other_value
+        end
+
+        self.class.new(*values)
+      end
+
+      def nullify(key)
+        send(:"#{key}=", nil)
+        self
+      end
+
+      [:klr].each do |empty_col|
+        define_method(empty_col) { nil }
+      end
+
+      [:bauberatung, :rechtsberatung, :vermittlung, :wohnbegleitung].each do |unused_col|
+        define_method(unused_col) { lufeb.nil? ? nil : 0 }
+      end
+    end
+
+    private
+
+    def report_data(report, table) # rubocop:disable Metrics/MethodLength
+      data = ->(value) { table.value_of(report.to_s, value).to_d }
+
+      [
+        data["aufwand_ertrag_fibu"],
+        data["abgrenzung_fibu"],
+        [data["verwaltung"], data["raeumlichkeiten"], data["mittelbeschaffung"]].reduce(:+),
+        data["beratung"],
+        data["medien_und_publikationen"],
+
+        data["jahreskurse"],
+        data["blockkurse"],
+        data["tageskurse"],
+        data["treffpunkte"],
+        data["lufeb"]
+      ]
+    end
+
+    def fetch_data_for(group) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
+      table = fp_class("CostAccounting::Table").new(group, year) # Fp2024::CostAccounting::Table
+
+      row = ->(report) { CostAccountingRow.new(*report_data(report, table)) }
+      empty = CostAccountingRow.empty_row
+      row_without_gemeinkosten = ->(report) { row[report].nullify(:gemeinkosten) }
+      row_with_method = ->(method) { CostAccountingRow.new(*send(method, table)) }
+
+      {
+        personalaufwand: row_with_method[:personalaufwand],
+        honorare: row[:honorare],
+        sachaufwand: [row[:raumaufwand], row[:uebriger_sachaufwand]].reduce(:+),
+        aufwand: empty,
+        gemeinkosten: row_with_method[:gemeinkosten],
+        umlagen: empty,
+        total_aufwand: empty,
+        leistungen: row_without_gemeinkosten[:leistungsertrag],
+        beitraege_iv: row_without_gemeinkosten[:beitraege_iv],
+        sonstige_beitraege: row_without_gemeinkosten[:sonstige_beitraege],
+        spenden_zweckgebunden: row_without_gemeinkosten[:direkte_spenden],
+        spenden_nicht_zweckgebunden: row_with_method[:indirekte_spenden]
+      }
+    end
+
+    def personalaufwand(table)
+      [
+        CostAccountingRow.new(*report_data(:lohnaufwand, table)),
+        CostAccountingRow.new(*report_data(:sozialversicherungsaufwand, table)),
+        CostAccountingRow.new(*report_data(:uebriger_personalaufwand, table))
+      ].reduce(:+)
+    end
+
+    def gemeinkosten(table)
+      Array.new(3, nil) + report_data(:total_umlagen, table)[3..]
+    end
+
+    def indirekte_spenden(table)
+      data = report_data(:indirekte_spenden, table)
+
+      [data[0], nil, nil, *data[3..]]
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/report/abschreibungen.rb
+++ b/app/domain/fp2024/cost_accounting/report/abschreibungen.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2020, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  module Report
+    class Abschreibungen < Base
+      self.kontengruppe = "692"
+
+      delegate_editable_fields %w[aufwand_ertrag_fibu
+        aufteilung_kontengruppen
+        abgrenzung_fibu]
+
+      alias_method :verwaltung, :aufwand_ertrag_ko_re
+      alias_method :total, :aufwand_ertrag_ko_re
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/report/base.rb
+++ b/app/domain/fp2024/cost_accounting/report/base.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2020, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  module Report
+    class Base
+      FIELDS = %w[aufwand_ertrag_fibu
+        abgrenzung_fibu
+        aufwand_ertrag_ko_re
+
+        raeumlichkeiten
+        verwaltung
+        mittelbeschaffung
+        beratung
+        medien_und_publikationen
+        jahreskurse
+        blockkurse
+        tageskurse
+        treffpunkte
+        lufeb
+        total
+        kontrolle].freeze
+
+      # The fields displayed in the detail view of the report.
+      class_attribute :used_fields
+      # Most commonly used fields, override in subclasses
+      self.used_fields = %w[aufwand_ertrag_fibu
+        abgrenzung_fibu
+        aufwand_ertrag_ko_re
+
+        beratung
+        medien_und_publikationen
+        treffpunkte
+        blockkurse
+        tageskurse
+        jahreskurse
+        lufeb
+        mittelbeschaffung
+        total
+        kontrolle]
+
+      # The editable fields of this report.
+      class_attribute :editable_fields
+      self.editable_fields = []
+
+      # The kind of the report, e.g. subtotal, total.
+      class_attribute :kind
+
+      # The kontengruppe of this report.
+      class_attribute :kontengruppe
+
+      # Whether this report counts as aufwand or ertrag
+      class_attribute :aufwand
+      self.aufwand = true
+
+      # Whether to include the Gemeinkosten fields (Räumlichkeiten, Geschäftsführung,
+      # Mittelbeschaffung) in the calculated total
+      class_attribute :total_includes_gemeinkostentraeger
+      self.total_includes_gemeinkostentraeger = true
+
+      class << self
+        def key
+          name.demodulize.underscore
+        end
+
+        def short_name(year)
+          scope = Featureperioden::Dispatcher.new(year).i18n_scope("cost_accounting")
+          I18n.t("report.#{key}.short_name",
+            scope: scope,
+            default: I18n.t("cost_accounting.report.#{key}.short_name"))
+        end
+
+        def human_name(year)
+          scope = Featureperioden::Dispatcher.new(year).i18n_scope("cost_accounting")
+          I18n.t("report.#{key}.name", scope: scope,
+            default: I18n.t("cost_accounting.report.#{key}.name"))
+        end
+
+        def delegate_editable_fields(fields)
+          self.editable_fields = fields
+          delegate(*fields, to: :record)
+        end
+
+        def editable?
+          editable_fields.present?
+        end
+      end
+
+      attr_reader :table
+
+      delegate :key, :editable?, to: :class
+      delegate :year, to: :table
+
+      def initialize(table)
+        @table = table
+      end
+
+      # define accessor methods for all fields, returning nil
+      FIELDS.each do |f|
+        define_method(f) {}
+      end
+
+      def short_name
+        self.class.short_name(year)
+      end
+
+      def human_name
+        self.class.human_name(year)
+      end
+
+      def aufwand_ertrag_ko_re
+        @aufwand_ertrag_ko_re ||= aufwand_ertrag_fibu.to_d -
+          abgrenzung_fibu.to_d
+      end
+
+      def gemeinkostentraeger
+        @gemeinkostentraeger ||= raeumlichkeiten.to_d + verwaltung.to_d + mittelbeschaffung.to_d
+      end
+
+      def total # rubocop:disable Metrics/AbcSize
+        @total ||= beratung.to_d +
+          medien_und_publikationen.to_d +
+          treffpunkte.to_d +
+          blockkurse.to_d +
+          tageskurse.to_d +
+          jahreskurse.to_d +
+          lufeb.to_d +
+          (total_includes_gemeinkostentraeger ? gemeinkostentraeger : 0)
+      end
+
+      def kontrolle
+        total - aufwand_ertrag_ko_re
+      end
+
+      def record
+        @record ||= table.cost_record(key)
+      end
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/report/beitraege_iv.rb
+++ b/app/domain/fp2024/cost_accounting/report/beitraege_iv.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2020, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  module Report
+    class BeitraegeIv < Base
+      self.kontengruppe = "330"
+
+      self.aufwand = false
+
+      delegate_editable_fields %w[aufwand_ertrag_fibu
+        aufteilung_kontengruppen
+        abgrenzung_fibu
+
+        beratung
+        medien_und_publikationen
+        treffpunkte
+        blockkurse
+        tageskurse
+        jahreskurse
+        lufeb]
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/report/course_related.rb
+++ b/app/domain/fp2024/cost_accounting/report/course_related.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2020, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  module Report
+    class CourseRelated < Base
+      COURSE_FIELDS = {blockkurse: "bk",
+                       tageskurse: "tk",
+                       jahreskurse: "sk",
+                       treffpunkte: "tp"}.freeze
+
+      COURSE_FIELDS.each do |field, lk|
+        define_method(field) do
+          table.course_costs(key, lk).try(:to_d)
+        end
+      end
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/report/deckungsbeitrag.rb
+++ b/app/domain/fp2024/cost_accounting/report/deckungsbeitrag.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2014, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  module Report
+    class Deckungsbeitrag < Base
+      self.kind = :deckungsbeitrag
+
+      def aufteilung_kontengruppen
+        nil
+      end
+
+      def aufwand_ertrag_fibu
+        nil
+      end
+
+      def abgrenzung_fibu
+        nil
+      end
+
+      def abgrenzung_dachorganisation
+        nil
+      end
+
+      def aufwand_ertrag_ko_re
+        nil
+      end
+
+      def personal
+        nil
+      end
+
+      def raeumlichkeiten
+        nil
+      end
+
+      def verwaltung
+        nil
+      end
+
+      def kontrolle
+        nil
+      end
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/report/deckungsbeitrag1.rb
+++ b/app/domain/fp2024/cost_accounting/report/deckungsbeitrag1.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2014, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  module Report
+    class Deckungsbeitrag1 < Deckungsbeitrag
+      def beratung
+        table.value_of("leistungsertrag", "beratung").to_d -
+          table.value_of("total_aufwand", "beratung").to_d
+      end
+
+      def medien_und_publikationen
+        table.value_of("leistungsertrag", "medien_und_publikationen").to_d -
+          table.value_of("total_aufwand", "medien_und_publikationen").to_d
+      end
+
+      def treffpunkte
+        table.value_of("leistungsertrag", "treffpunkte").to_d -
+          table.value_of("total_aufwand", "treffpunkte").to_d
+      end
+
+      def blockkurse
+        table.value_of("leistungsertrag", "blockkurse").to_d -
+          table.value_of("total_aufwand", "blockkurse").to_d
+      end
+
+      def tageskurse
+        table.value_of("leistungsertrag", "tageskurse").to_d -
+          table.value_of("total_aufwand", "tageskurse").to_d
+      end
+
+      def jahreskurse
+        table.value_of("leistungsertrag", "jahreskurse").to_d -
+          table.value_of("total_aufwand", "jahreskurse").to_d
+      end
+
+      def lufeb
+        table.value_of("leistungsertrag", "lufeb").to_d -
+          table.value_of("total_aufwand", "lufeb").to_d
+      end
+
+      def mittelbeschaffung
+        table.value_of("leistungsertrag", "mittelbeschaffung").to_d -
+          table.value_of("total_aufwand", "mittelbeschaffung").to_d
+      end
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/report/deckungsbeitrag2.rb
+++ b/app/domain/fp2024/cost_accounting/report/deckungsbeitrag2.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2014, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  module Report
+    class Deckungsbeitrag2 < Deckungsbeitrag
+      def beratung
+        table.value_of("deckungsbeitrag1", "beratung").to_d -
+          table.value_of("total_umlagen", "beratung").to_d +
+          table.value_of("direkte_spenden", "beratung").to_d +
+          table.value_of("indirekte_spenden", "beratung").to_d
+      end
+
+      def medien_und_publikationen
+        table.value_of("deckungsbeitrag1", "medien_und_publikationen").to_d -
+          table.value_of("total_umlagen", "medien_und_publikationen").to_d +
+          table.value_of("direkte_spenden", "medien_und_publikationen").to_d +
+          table.value_of("indirekte_spenden", "medien_und_publikationen").to_d
+      end
+
+      def treffpunkte
+        table.value_of("deckungsbeitrag1", "treffpunkte").to_d -
+          table.value_of("total_umlagen", "treffpunkte").to_d +
+          table.value_of("direkte_spenden", "treffpunkte").to_d +
+          table.value_of("indirekte_spenden", "treffpunkte").to_d
+      end
+
+      def blockkurse
+        table.value_of("deckungsbeitrag1", "blockkurse").to_d -
+          table.value_of("total_umlagen", "blockkurse").to_d +
+          table.value_of("direkte_spenden", "blockkurse").to_d +
+          table.value_of("indirekte_spenden", "blockkurse").to_d
+      end
+
+      def tageskurse
+        table.value_of("deckungsbeitrag1", "tageskurse").to_d -
+          table.value_of("total_umlagen", "tageskurse").to_d +
+          table.value_of("direkte_spenden", "tageskurse").to_d +
+          table.value_of("indirekte_spenden", "tageskurse").to_d
+      end
+
+      def jahreskurse
+        table.value_of("deckungsbeitrag1", "jahreskurse").to_d -
+          table.value_of("total_umlagen", "jahreskurse").to_d +
+          table.value_of("direkte_spenden", "jahreskurse").to_d +
+          table.value_of("indirekte_spenden", "jahreskurse").to_d
+      end
+
+      def lufeb
+        table.value_of("deckungsbeitrag1", "lufeb").to_d -
+          table.value_of("total_umlagen", "lufeb").to_d +
+          table.value_of("direkte_spenden", "lufeb").to_d +
+          table.value_of("indirekte_spenden", "lufeb").to_d
+      end
+
+      def mittelbeschaffung
+        table.value_of("deckungsbeitrag1", "mittelbeschaffung").to_d -
+          table.value_of("total_umlagen", "mittelbeschaffung").to_d +
+          table.value_of("direkte_spenden", "mittelbeschaffung").to_d +
+          table.value_of("indirekte_spenden", "mittelbeschaffung").to_d
+      end
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/report/deckungsbeitrag3.rb
+++ b/app/domain/fp2024/cost_accounting/report/deckungsbeitrag3.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2014, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  module Report
+    class Deckungsbeitrag3 < Deckungsbeitrag
+      def beratung
+        table.value_of("deckungsbeitrag2", "beratung").to_d +
+          table.value_of("sonstige_beitraege", "beratung").to_d
+      end
+
+      def medien_und_publikationen
+        table.value_of("deckungsbeitrag2", "medien_und_publikationen").to_d +
+          table.value_of("sonstige_beitraege", "medien_und_publikationen").to_d
+      end
+
+      def treffpunkte
+        table.value_of("deckungsbeitrag2", "treffpunkte").to_d +
+          table.value_of("sonstige_beitraege", "treffpunkte").to_d
+      end
+
+      def blockkurse
+        table.value_of("deckungsbeitrag2", "blockkurse").to_d +
+          table.value_of("sonstige_beitraege", "blockkurse").to_d
+      end
+
+      def tageskurse
+        table.value_of("deckungsbeitrag2", "tageskurse").to_d +
+          table.value_of("sonstige_beitraege", "tageskurse").to_d
+      end
+
+      def jahreskurse
+        table.value_of("deckungsbeitrag2", "jahreskurse").to_d +
+          table.value_of("sonstige_beitraege", "jahreskurse").to_d
+      end
+
+      def lufeb
+        table.value_of("deckungsbeitrag2", "lufeb").to_d +
+          table.value_of("sonstige_beitraege", "lufeb").to_d
+      end
+
+      def mittelbeschaffung
+        table.value_of("deckungsbeitrag2", "mittelbeschaffung").to_d +
+          table.value_of("sonstige_beitraege", "mittelbeschaffung").to_d
+      end
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/report/deckungsbeitrag4.rb
+++ b/app/domain/fp2024/cost_accounting/report/deckungsbeitrag4.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2014, 2020, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  module Report
+    class Deckungsbeitrag4 < Deckungsbeitrag
+      def beratung
+        table.value_of("deckungsbeitrag3", "beratung").to_d +
+          table.value_of("beitraege_iv", "beratung").to_d
+      end
+
+      def medien_und_publikationen
+        table.value_of("deckungsbeitrag3", "medien_und_publikationen").to_d +
+          table.value_of("beitraege_iv", "medien_und_publikationen").to_d
+      end
+
+      def treffpunkte
+        table.value_of("deckungsbeitrag3", "treffpunkte").to_d +
+          table.value_of("beitraege_iv", "treffpunkte").to_d
+      end
+
+      def blockkurse
+        table.value_of("deckungsbeitrag3", "blockkurse").to_d +
+          table.value_of("beitraege_iv", "blockkurse").to_d
+      end
+
+      def tageskurse
+        table.value_of("deckungsbeitrag3", "tageskurse").to_d +
+          table.value_of("beitraege_iv", "tageskurse").to_d
+      end
+
+      def jahreskurse
+        table.value_of("deckungsbeitrag3", "jahreskurse").to_d +
+          table.value_of("beitraege_iv", "jahreskurse").to_d
+      end
+
+      def lufeb
+        table.value_of("deckungsbeitrag3", "lufeb").to_d +
+          table.value_of("beitraege_iv", "lufeb").to_d
+      end
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/report/direkte_spenden.rb
+++ b/app/domain/fp2024/cost_accounting/report/direkte_spenden.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2020, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  module Report
+    class DirekteSpenden < Base
+      self.kontengruppe = "3321/3323/32/900"
+
+      self.aufwand = false
+
+      delegate_editable_fields %w[aufwand_ertrag_fibu
+        aufteilung_kontengruppen
+        abgrenzung_fibu
+
+        beratung
+        medien_und_publikationen
+        treffpunkte
+        blockkurse
+        tageskurse
+        jahreskurse
+        lufeb]
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/report/direkte_spenden_ausserhalb.rb
+++ b/app/domain/fp2024/cost_accounting/report/direkte_spenden_ausserhalb.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2020, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  module Report
+    class DirekteSpendenAusserhalb < Base
+      self.kontengruppe = "3322/920"
+
+      self.aufwand = false
+
+      delegate_editable_fields %w[aufwand_ertrag_fibu
+        aufteilung_kontengruppen]
+
+      alias_method :abgrenzung_fibu, :aufwand_ertrag_fibu
+
+      def kontrolle
+        nil
+      end
+
+      def total
+        nil
+      end
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/report/honorare.rb
+++ b/app/domain/fp2024/cost_accounting/report/honorare.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2020, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  module Report
+    class Honorare < CourseRelated
+      self.kontengruppe = "509/4300"
+
+      self.used_fields += %w[verwaltung]
+
+      delegate_editable_fields %w[aufwand_ertrag_fibu
+        aufteilung_kontengruppen
+        abgrenzung_fibu
+
+        verwaltung
+        beratung
+        medien_und_publikationen
+        lufeb
+        mittelbeschaffung]
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/report/indirekte_spenden.rb
+++ b/app/domain/fp2024/cost_accounting/report/indirekte_spenden.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2020, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  module Report
+    class IndirekteSpenden < Base
+      self.kontengruppe = "3320/680-685/74/333/335/910"
+
+      self.aufwand = false
+
+      delegate_editable_fields %w[aufwand_ertrag_fibu
+        aufteilung_kontengruppen
+
+        beratung
+        medien_und_publikationen
+        treffpunkte
+        blockkurse
+        tageskurse
+        jahreskurse
+        lufeb]
+
+      def abgrenzung_fibu
+        abgrenzung_factor && (abgrenzung_factor * aufwand_ertrag_fibu.to_d)
+      end
+
+      def abgrenzung_factor
+        @abgrenzung_factor ||= table.value_of("total_aufwand", "aufwand_ertrag_fibu").nonzero? &&
+          (1 - table.value_of("vollkosten", "total").to_d /
+           table.value_of("total_aufwand", "aufwand_ertrag_fibu").to_d)
+      end
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/report/leistungsertrag.rb
+++ b/app/domain/fp2024/cost_accounting/report/leistungsertrag.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2020, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  module Report
+    class Leistungsertrag < Base
+      self.kontengruppe = "30"
+
+      self.aufwand = false
+
+      delegate_editable_fields %w[aufwand_ertrag_fibu
+        aufteilung_kontengruppen
+        abgrenzung_fibu
+
+        beratung
+        medien_und_publikationen
+        treffpunkte
+        blockkurse
+        tageskurse
+        jahreskurse
+        lufeb]
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/report/lohnaufwand.rb
+++ b/app/domain/fp2024/cost_accounting/report/lohnaufwand.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2014, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  module Report
+    class Lohnaufwand < TimeDistributed
+      self.kontengruppe = "500"
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/report/raumaufwand.rb
+++ b/app/domain/fp2024/cost_accounting/report/raumaufwand.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2020, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  module Report
+    class Raumaufwand < CourseRelated
+      self.kontengruppe = "600"
+
+      self.used_fields += %w[raeumlichkeiten]
+
+      delegate_editable_fields %w[aufwand_ertrag_fibu
+        aufteilung_kontengruppen
+        abgrenzung_fibu
+
+        raeumlichkeiten
+        beratung
+        medien_und_publikationen
+        lufeb
+        mittelbeschaffung]
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/report/separator.rb
+++ b/app/domain/fp2024/cost_accounting/report/separator.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2020, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  module Report
+    class Separator < Base
+      self.kind = :separator
+
+      def aufwand_ertrag_ko_re
+        nil
+      end
+
+      def kontrolle
+        nil
+      end
+
+      def total
+        nil
+      end
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/report/sonstige_beitraege.rb
+++ b/app/domain/fp2024/cost_accounting/report/sonstige_beitraege.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2020, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  module Report
+    class SonstigeBeitraege < Base
+      self.kontengruppe = "331"
+
+      self.aufwand = false
+
+      delegate_editable_fields %w[aufwand_ertrag_fibu
+        aufteilung_kontengruppen
+        abgrenzung_fibu
+
+        beratung
+        medien_und_publikationen
+        treffpunkte
+        blockkurse
+        tageskurse
+        jahreskurse
+        lufeb]
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/report/sozialversicherungsaufwand.rb
+++ b/app/domain/fp2024/cost_accounting/report/sozialversicherungsaufwand.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2014, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  module Report
+    class Sozialversicherungsaufwand < TimeDistributed
+      self.kontengruppe = "507"
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/report/subtotal.rb
+++ b/app/domain/fp2024/cost_accounting/report/subtotal.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2014, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  module Report
+    class Subtotal < Base
+      class_attribute :summed_reports, :summed_fields
+
+      self.kind = :subtotal
+
+      class << self
+        def define_summed_field_methods
+          summed_fields.each do |field|
+            define_method(field) do
+              @summed_fields ||= {}
+              @summed_fields[field] ||=
+                summed_reports.collect do |report|
+                  table.value_of(report, field).to_d
+                end.sum
+            end
+          end
+        end
+      end
+
+      def kontrolle
+        nil
+      end
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/report/time_distributed.rb
+++ b/app/domain/fp2024/cost_accounting/report/time_distributed.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2022, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  module Report
+    class TimeDistributed < Base
+      TIME_FIELDS = %w[verwaltung
+        beratung
+        treffpunkte
+        blockkurse
+        tageskurse
+        jahreskurse
+        lufeb
+        mittelbeschaffung
+        medien_und_publikationen].freeze
+
+      self.used_fields += %w[verwaltung]
+
+      delegate_editable_fields %w[aufwand_ertrag_fibu
+        aufteilung_kontengruppen
+        abgrenzung_fibu]
+
+      delegate :time_record, to: :table
+
+      TIME_FIELDS.each do |field|
+        define_method(field) do # rubocop:disable Metrics/MethodLength
+          @time_fields ||= {}
+          @time_fields[field] ||=
+            if aufwand_ertrag_ko_re.nonzero? && time_record.total_paragraph_74.nonzero?
+              time_record_value =
+                case field
+                when "lufeb" then sum_fields(:lufeb, :kurse_grundlagen)
+                when "treffpunkte" then sum_fields(:treffpunkte, :treffpunkte_grundlagen)
+                else sum_fields(field.to_sym)
+                end
+
+              aufwand_ertrag_ko_re * time_record_value / time_record.total_paragraph_74.abs
+            end
+        end
+      end
+
+      private
+
+      def sum_fields(main_field, *additional_fields)
+        ([main_field] + additional_fields).map do |field|
+          time_record.send(field).to_d
+        end.sum
+      end
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/report/total_aufwand.rb
+++ b/app/domain/fp2024/cost_accounting/report/total_aufwand.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2020, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  module Report
+    # Total Aufwand/Kosten
+    class TotalAufwand < Subtotal
+      self.total_includes_gemeinkostentraeger = false
+
+      self.used_fields += %w[
+        verwaltung
+      ]
+
+      self.summed_reports = %w[
+        total_personalaufwand
+        raumaufwand
+        uebriger_sachaufwand
+        abschreibungen
+      ]
+
+      self.summed_fields = %w[
+        aufwand_ertrag_fibu
+        abgrenzung_fibu
+
+        beratung
+        medien_und_publikationen
+        treffpunkte
+        blockkurse
+        tageskurse
+        jahreskurse
+        lufeb
+      ]
+
+      self.total_includes_gemeinkostentraeger = false
+
+      define_summed_field_methods
+
+      def total
+        super + table.value_of("total_umlagen", "gemeinkostentraeger").to_d
+      end
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/report/total_ertraege.rb
+++ b/app/domain/fp2024/cost_accounting/report/total_ertraege.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2020, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  module Report
+    class TotalErtraege < Subtotal
+      self.used_fields += %w[verwaltung]
+
+      self.summed_reports = %w[leistungsertrag
+        beitraege_iv
+        sonstige_beitraege
+        direkte_spenden
+        indirekte_spenden
+        direkte_spenden_ausserhalb]
+
+      self.summed_fields = %w[aufwand_ertrag_fibu
+        abgrenzung_fibu
+
+        beratung
+        medien_und_publikationen
+        treffpunkte
+        blockkurse
+        tageskurse
+        jahreskurse
+        lufeb
+        mittelbeschaffung]
+
+      define_summed_field_methods
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/report/total_personalaufwand.rb
+++ b/app/domain/fp2024/cost_accounting/report/total_personalaufwand.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2020, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  module Report
+    class TotalPersonalaufwand < Subtotal
+      self.used_fields += %w[verwaltung]
+
+      self.summed_reports = %w[lohnaufwand
+        sozialversicherungsaufwand
+        uebriger_personalaufwand
+        honorare]
+
+      self.summed_fields = %w[aufwand_ertrag_fibu
+        abgrenzung_fibu
+
+        verwaltung
+        beratung
+        treffpunkte
+        blockkurse
+        tageskurse
+        jahreskurse
+        lufeb
+        mittelbeschaffung
+        medien_und_publikationen]
+
+      define_summed_field_methods
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/report/total_umlagen.rb
+++ b/app/domain/fp2024/cost_accounting/report/total_umlagen.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2014, 2020, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  module Report
+    # Gemeinkosten
+    class TotalUmlagen < Subtotal
+      self.total_includes_gemeinkostentraeger = false
+
+      self.summed_reports = %w[
+        umlage_mittelbeschaffung
+
+        total_personalaufwand
+        raumaufwand
+        uebriger_sachaufwand
+        abschreibungen
+      ]
+
+      self.summed_fields = %w[
+        mittelbeschaffung
+        verwaltung
+        raeumlichkeiten
+      ]
+
+      class_attribute :topic_fields
+      self.topic_fields = %w[
+        beratung
+        medien_und_publikationen
+        treffpunkte
+        blockkurse
+        tageskurse
+        jahreskurse
+        lufeb
+      ]
+
+      # this deviates from a "normal" subtotal as specific fields are calculated
+      # with specific quotas derived from other specific field. The specifics are
+      # mostly contained in the gemeinkosten_quota-method.
+      topic_fields.each do |field|
+        define_method(field) do
+          gemeinkostentraeger * gemeinkosten_quota(field).to_d
+        end
+      end
+
+      define_summed_field_methods
+
+      def aufwand_ertrag_ko_re
+        nil
+      end
+
+      private
+
+      def gemeinkosten_quota(field)
+        has_employees = table.value_of("lohnaufwand", "total").positive?
+
+        quota_base = (has_employees ? :personalaufwand : :direktkosten)
+
+        one_topic = send(:"#{quota_base}_for_topic", field)
+        all_topics = send(:"total_#{quota_base}_for_all_topics")
+
+        return 0 if one_topic.zero? || all_topics.zero?
+
+        one_topic / all_topics
+      end
+
+      def personalaufwand_for_topic(field)
+        table.value_of("total_personalaufwand", field).to_d - table.value_of("honorare", field).to_d
+      end
+
+      def direktkosten_for_topic(field)
+        [
+          table.value_of("raumaufwand", field).to_d,
+          table.value_of("uebriger_sachaufwand", field).to_d,
+          table.value_of("honorare", field).to_d
+        ].sum
+      end
+
+      def total_personalaufwand_for_all_topics
+        @total_personalaufwand_for_all_topics ||=
+          self.class.topic_fields.sum { |field| personalaufwand_for_topic(field) }
+      end
+
+      def total_direktkosten_for_all_topics
+        @total_direktkosten_for_all_topics ||=
+          self.class.topic_fields.sum { |field| direktkosten_for_topic(field) }
+      end
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/report/uebriger_personalaufwand.rb
+++ b/app/domain/fp2024/cost_accounting/report/uebriger_personalaufwand.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2014, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  module Report
+    class UebrigerPersonalaufwand < TimeDistributed
+      self.kontengruppe = "508"
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/report/uebriger_sachaufwand.rb
+++ b/app/domain/fp2024/cost_accounting/report/uebriger_sachaufwand.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2020, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  module Report
+    class UebrigerSachaufwand < CourseRelated
+      self.kontengruppe = "40-43/61-67"
+
+      self.used_fields += %w[verwaltung]
+
+      delegate_editable_fields %w[aufwand_ertrag_fibu
+        aufteilung_kontengruppen
+        abgrenzung_fibu
+
+        verwaltung
+        beratung
+        medien_und_publikationen
+        lufeb
+        mittelbeschaffung]
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/report/umlage_mittelbeschaffung.rb
+++ b/app/domain/fp2024/cost_accounting/report/umlage_mittelbeschaffung.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2020, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  module Report
+    class UmlageMittelbeschaffung < Base
+      delegate :time_record, to: :table
+
+      FIELDS = %w[beratung
+        treffpunkte
+        blockkurse
+        tageskurse
+        jahreskurse
+        lufeb
+        medien_und_publikationen].freeze
+
+      FIELDS.each do |field|
+        define_method(field) do
+          @allocated_fields ||= {}
+
+          if mittelbeschaffung.positive?
+            @allocated_fields[field] ||= if time_record.total.positive?
+              allocated_with_time_record(field)
+            else
+              allocated_without_time_record(field)
+            end
+          end
+        end
+      end
+
+      def aufwand_ertrag_ko_re
+        nil
+      end
+
+      def mittelbeschaffung
+        @mittelbeschaffung ||=
+          table.value_of("total_aufwand", "mittelbeschaffung").to_d +
+          table.value_of("umlage_personal", "mittelbeschaffung").to_d +
+          table.value_of("umlage_raeumlichkeiten", "mittelbeschaffung").to_d +
+          table.value_of("umlage_verwaltung", "mittelbeschaffung").to_d
+      end
+
+      def total # rubocop:disable Metrics/AbcSize
+        @total ||= beratung.to_d +
+          treffpunkte.to_d +
+          blockkurse.to_d +
+          tageskurse.to_d +
+          jahreskurse.to_d +
+          lufeb.to_d +
+          medien_und_publikationen.to_d
+      end
+
+      def kontrolle
+        total - mittelbeschaffung
+      end
+
+      private
+
+      def allocated_with_time_record(field)
+        if relevante_zeit.positive?
+          mittelbeschaffung * time_record.send(field).to_d / relevante_zeit
+        end
+      end
+
+      def allocated_without_time_record(field)
+        if relevanter_aufwand.positive?
+          mittelbeschaffung * aufwand(field).to_d / relevanter_aufwand
+        end
+      end
+
+      def relevante_zeit
+        time_record.total_paragraph_74 - time_record.verwaltung.to_i
+      end
+
+      def relevanter_aufwand
+        @relevanter_aufwand ||=
+          FIELDS.inject(0) do |sum, field|
+            aufwand(field).to_d + sum
+          end
+      end
+
+      def aufwand(field)
+        table.value_of("total_aufwand", field).to_d
+      end
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/report/umlage_personal.rb
+++ b/app/domain/fp2024/cost_accounting/report/umlage_personal.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2014, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  module Report
+    class UmlagePersonal < Base
+      # This report has no data
+
+      def aufwand_ertrag_ko_re
+        nil
+      end
+
+      def total
+        nil
+      end
+
+      def kontrolle
+        nil
+      end
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/report/umlage_raeumlichkeiten.rb
+++ b/app/domain/fp2024/cost_accounting/report/umlage_raeumlichkeiten.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2020, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  module Report
+    class UmlageRaeumlichkeiten < Base
+      delegate :time_record, to: :table
+
+      FIELDS = %w[verwaltung
+        mittelbeschaffung
+        beratung
+        treffpunkte
+        blockkurse
+        tageskurse
+        jahreskurse
+        lufeb
+        medien_und_publikationen].freeze
+
+      FIELDS.each do |field|
+        define_method(field) do
+          @allocated_fields ||= {}
+
+          if raeumlichkeiten.positive?
+            @allocated_fields[field] ||= if time_record.total.positive?
+              allocated_with_time_record(field)
+            else
+              allocated_without_time_record(field)
+            end
+          end
+        end
+      end
+
+      def aufwand_ertrag_ko_re
+        nil
+      end
+
+      def raeumlichkeiten
+        @raeumlichkeiten ||=
+          table.value_of("total_aufwand", "raeumlichkeiten").to_d +
+          table.value_of("umlage_personal", "raeumlichkeiten").to_d
+      end
+
+      def total # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
+        @total ||= verwaltung.to_d +
+          mittelbeschaffung.to_d +
+          beratung.to_d +
+          treffpunkte.to_d +
+          blockkurse.to_d +
+          tageskurse.to_d +
+          jahreskurse.to_d +
+          lufeb.to_d +
+          medien_und_publikationen.to_d
+      end
+
+      def kontrolle
+        total - raeumlichkeiten
+      end
+
+      private
+
+      def allocated_with_time_record(field)
+        if relevante_zeit.positive?
+          raeumlichkeiten * time_record.send(field).to_d / relevante_zeit
+        end
+      end
+
+      def allocated_without_time_record(field)
+        if relevanter_aufwand.positive?
+          raeumlichkeiten * aufwand(field).to_d / relevanter_aufwand
+        end
+      end
+
+      def relevante_zeit
+        time_record.total_paragraph_74
+      end
+
+      def relevanter_aufwand
+        @relevanter_aufwand ||=
+          FIELDS.inject(0) do |sum, field|
+            aufwand(field).to_d + sum
+          end
+      end
+
+      def aufwand(field)
+        table.value_of("total_aufwand", field).to_d
+      end
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/report/umlage_verwaltung.rb
+++ b/app/domain/fp2024/cost_accounting/report/umlage_verwaltung.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2020, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  module Report
+    class UmlageVerwaltung < Base
+      delegate :time_record, to: :table
+
+      FIELDS = %w[mittelbeschaffung
+        beratung
+        treffpunkte
+        blockkurse
+        tageskurse
+        jahreskurse
+        lufeb
+        medien_und_publikationen].freeze
+
+      FIELDS.each do |field|
+        define_method(field) do
+          @allocated_fields ||= {}
+
+          if verwaltung.positive?
+            @allocated_fields[field] ||= if time_record.total.positive?
+              allocated_with_time_record(field)
+            else
+              allocated_without_time_record(field)
+            end
+          end
+        end
+      end
+
+      def aufwand_ertrag_ko_re
+        nil
+      end
+
+      def verwaltung
+        @verwaltung ||=
+          table.value_of("total_aufwand", "verwaltung").to_d +
+          table.value_of("umlage_personal", "verwaltung").to_d +
+          table.value_of("umlage_raeumlichkeiten", "verwaltung").to_d
+      end
+
+      def total # rubocop:disable Metrics/AbcSize
+        @total ||= mittelbeschaffung.to_d +
+          beratung.to_d +
+          treffpunkte.to_d +
+          blockkurse.to_d +
+          tageskurse.to_d +
+          jahreskurse.to_d +
+          lufeb.to_d +
+          medien_und_publikationen.to_d
+      end
+
+      def kontrolle
+        total - verwaltung
+      end
+
+      private
+
+      def allocated_with_time_record(field)
+        if relevante_zeit.positive?
+          verwaltung * time_record.send(field).to_d / relevante_zeit
+        end
+      end
+
+      def allocated_without_time_record(field)
+        if relevanter_aufwand.positive?
+          verwaltung * aufwand(field).to_d / relevanter_aufwand
+        end
+      end
+
+      def relevante_zeit
+        time_record.total_paragraph_74 - time_record.verwaltung.to_i
+      end
+
+      def relevanter_aufwand
+        @relevanter_aufwand ||=
+          FIELDS.inject(0) do |sum, field|
+            aufwand(field).to_d + sum
+          end
+      end
+
+      def aufwand(field)
+        table.value_of("total_aufwand", field).to_d
+      end
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/report/unternehmenserfolg.rb
+++ b/app/domain/fp2024/cost_accounting/report/unternehmenserfolg.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2014, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  module Report
+    class Unternehmenserfolg < Base
+      self.kind = :unternehmenserfolg
+
+      def aufwand_ertrag_ko_re
+        nil
+      end
+
+      def total
+        @total ||= table.value_of("total_ertraege", "aufwand_ertrag_fibu").to_d -
+          table.value_of("total_aufwand", "aufwand_ertrag_fibu").to_d
+      end
+
+      def kontrolle
+        nil
+      end
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/report/vollkosten.rb
+++ b/app/domain/fp2024/cost_accounting/report/vollkosten.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2014, 2020, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  module Report
+    class Vollkosten < Subtotal
+      self.summed_reports = %w[
+        total_aufwand
+        total_umlagen
+      ]
+
+      self.summed_fields = %w[
+        beratung
+        treffpunkte
+        blockkurse
+        tageskurse
+        jahreskurse
+        lufeb
+        medien_und_publikationen
+      ]
+
+      self.total_includes_gemeinkostentraeger = false
+
+      define_summed_field_methods
+
+      def aufwand_ertrag_ko_re
+        nil
+      end
+    end
+  end
+end

--- a/app/domain/fp2024/cost_accounting/table.rb
+++ b/app/domain/fp2024/cost_accounting/table.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2020-2022, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CostAccounting
+  class Table
+    REPORTS = [
+      Report::Lohnaufwand,
+      Report::Sozialversicherungsaufwand,
+      Report::UebrigerPersonalaufwand,
+      Report::Honorare,
+      Report::TotalPersonalaufwand,
+      Report::Raumaufwand,
+      Report::UebrigerSachaufwand,
+      Report::Abschreibungen,
+      Report::TotalAufwand,
+      Report::UmlagePersonal,
+      Report::UmlageRaeumlichkeiten,
+      Report::UmlageVerwaltung,
+      Report::UmlageMittelbeschaffung,
+      Report::TotalUmlagen,
+      Report::Vollkosten,
+      Report::Leistungsertrag,
+      Report::BeitraegeIv,
+      Report::SonstigeBeitraege,
+      Report::DirekteSpenden,
+      Report::IndirekteSpenden,
+      Report::DirekteSpendenAusserhalb,
+      Report::TotalErtraege,
+      Report::Deckungsbeitrag1,
+      Report::Deckungsbeitrag2,
+      Report::Deckungsbeitrag3,
+      Report::Unternehmenserfolg,
+      Report::Deckungsbeitrag4
+    ].freeze
+
+    VISIBLE_REPORTS = [
+      Report::Lohnaufwand,
+      Report::Sozialversicherungsaufwand,
+      Report::UebrigerPersonalaufwand,
+      Report::Honorare,
+      Report::TotalPersonalaufwand,
+      Report::Raumaufwand,
+      Report::UebrigerSachaufwand,
+      Report::TotalAufwand,
+      Report::TotalUmlagen,
+      Report::Vollkosten,
+      Report::Leistungsertrag,
+      Report::BeitraegeIv,
+      Report::SonstigeBeitraege,
+      Report::DirekteSpenden,
+      Report::IndirekteSpenden,
+      Report::TotalErtraege,
+      Report::Unternehmenserfolg,
+      Report::Deckungsbeitrag4
+    ].freeze
+
+    GEMEINKOSTEN_FIELDS = %w[
+      raeumlichkeiten
+      mittelbeschaffung
+      verwaltung
+    ].freeze
+
+    SECTION_FIELDS = %w[
+      beratung
+      medien_und_publikationen
+      jahreskurse
+      blockkurse
+      tageskurse
+      treffpunkte
+      lufeb
+    ].freeze
+
+    attr_reader :group, :year
+
+    class << self
+      def fields
+        Report::Base::FIELDS - %w[abgrenzung_dachorganisation personal]
+      end
+    end
+
+    def initialize(group, year)
+      @group = group
+      @year = year
+    end
+
+    def section_fields
+      SECTION_FIELDS
+    end
+
+    def gemeinkosten_fields
+      GEMEINKOSTEN_FIELDS
+    end
+
+    def time_record
+      @time_record ||= ::TimeRecord::EmployeeTime.where(group_id: group.id, year: year)
+        .first_or_initialize
+    end
+
+    def reports
+      @reports ||= REPORTS.each_with_object({}) do |report, hash|
+        hash[report.key] = report.new(self)
+      end
+    end
+
+    def visible_reports
+      @visible_reports ||= VISIBLE_REPORTS.map { |report| [report.key, reports[report.key]] }.to_h
+    end
+
+    def course_costs(report_key, leistungskategorie)
+      @course_costs ||= prepare_course_costs
+      @course_costs[leistungskategorie][report_key]
+    end
+
+    # "Total Gemeinkosten" in "Gemeinkostenumlage"
+    def general_costs(field)
+      vollkosten = value_of("vollkosten", field).to_d
+      direkte_kosten = %w[
+        raumaufwand
+        uebriger_sachaufwand
+        honorare
+      ].sum { |report| value_of(report, field).to_d }
+
+      vollkosten - direkte_kosten
+    end
+
+    def value_of(report, field)
+      reports.fetch(report).send(field)
+    end
+
+    def cost_record(report_key)
+      cost_records[report_key] ||=
+        CostAccountingRecord.new(group_id: group.id, year: year, report: report_key)
+    end
+
+    def set_records(time_record, cost_records, course_costs)
+      @time_record = time_record || TimeRecord::EmployeeTime.new(group_id: group.id, year: year)
+      @cost_records = cost_records || {}
+      @course_costs = course_costs || Hash.new { |h, k| h[k] = {} }
+    end
+
+    private
+
+    def cost_records
+      @cost_records ||= begin
+        records = CostAccountingRecord.calculation_fields.where(group_id: group.id, year: year)
+        records.index_by { |r| r.report }
+      end
+    end
+
+    def prepare_course_costs
+      nested_hash = Hash.new { |h, k| h[k] = {} }
+      load_course_costs
+        .each_with_object(nested_hash) do |(lk, honorare, unterkunft, uebriges), hash|
+        hash[lk] = {"honorare" => honorare,
+                     "raumaufwand" => unterkunft,
+                     "uebriger_sachaufwand" => uebriges}
+      end
+    end
+
+    def load_course_costs
+      Event::CourseRecord
+        .joins(:event)
+        .group("events.leistungskategorie")
+        .where(year: year, subventioniert: true)
+        .merge(Event.with_group_id(group.id))
+        .pluck("leistungskategorie, " \
+              "SUM(honorare_inkl_sozialversicherung), SUM(unterkunft), SUM(uebriges)")
+    end
+  end
+end

--- a/app/domain/fp2024/course_reporting/aggregation.rb
+++ b/app/domain/fp2024/course_reporting/aggregation.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2015-2021, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::CourseReporting
+  class Aggregation
+    COUNTS = [
+      :anzahl_kurse,
+      :kursdauer,
+
+      :teilnehmende_behinderte,
+      :teilnehmende_angehoerige,
+      :teilnehmende_weitere,
+
+      :absenzen_behinderte,
+      :absenzen_angehoerige,
+      :absenzen_weitere,
+
+      :leiterinnen,
+      :fachpersonen,
+      :hilfspersonal_ohne_honorar,
+      :hilfspersonal_mit_honorar,
+      :betreuerinnen,
+      :kuechenpersonal,
+
+      :betreuungsstunden,
+
+      :honorare_inkl_sozialversicherung,
+      :unterkunft,
+      :uebriges,
+
+      :beitraege_teilnehmende,
+      :gemeinkostenanteil,
+      :direkter_aufwand,
+
+      :tage_behinderte,
+      :tage_angehoerige,
+      :tage_weitere
+    ].freeze
+
+    RUBY_SUMMED_ATTRS = COUNTS + [
+      :anzahl_spezielle_unterkunft
+    ].freeze
+
+    attr_accessor :group_id, :year, :leistungskategorie, :subventioniert
+
+    def initialize(group_id, year, leistungskategorie, _zugeteilte_kategorien, subventioniert)
+      @group_id = group_id
+      @year = year
+      @leistungskategorie = leistungskategorie
+      @subventioniert = subventioniert
+    end
+
+    def course_counts(fachkonzept, kursart, attr)
+      data.fetch(fachkonzept).fetch(kursart).send(attr)
+    end
+
+    def kursarten
+      [] # wurde durch Aufteilung nach Kursinhalt/kriterien ersetzt
+    end
+
+    def kursfachkonzepte
+      Event::Reportable::KURSFACHKONZEPTE
+    end
+
+    def scope
+      Event::CourseRecord
+        .joins(:event)
+        .group(:kursart, :fachkonzept)
+        .merge(group_id ? Event.with_group_id(group_id) : {})
+        .where(events: {leistungskategorie: leistungskategorie},
+          event_course_records: {
+            year: year,
+            subventioniert: subventioniert
+          })
+    end
+
+    private
+
+    def data
+      @data ||= begin
+        hash = Hash.new { |k, v| k[v] = {} }
+        build_categories(hash)
+        build_totals(hash)
+        hash
+      end
+    end
+
+    def build_categories(hash)
+      kursfachkonzepte.each do |kriterium|
+        hash[kriterium]["total"] = total(records_for(:fachkonzept, kriterium))
+        kursarten.each do |kursart|
+          hash[kriterium][kursart] = find_record(kriterium, kursart)
+        end
+      end
+    end
+
+    def build_totals(hash)
+      hash["all"]["total"] = total(records)
+      kursarten.each do |kursart|
+        hash["all"][kursart] = total(records_for(:kursart, kursart))
+      end
+    end
+
+    def records_for(attr, value)
+      records.select { |record| record.event.send(attr) == value }
+    end
+
+    def find_record(fachkonzept, kursart)
+      records.find { |r| r.fachkonzept == fachkonzept && r.kursart == kursart } ||
+        empty_course_record
+    end
+
+    def records
+      @records ||= scope.select(select_clause)
+    end
+
+    def empty_course_record
+      Event::CourseRecord.new(anzahl_kurse: nil, year: year).tap do |cr|
+        cr.define_singleton_method(:aggregation_record?) { true }
+        cr.define_singleton_method(:"#{leistungskategorie}?") { true }
+      end
+    end
+
+    def total(course_records)
+      RUBY_SUMMED_ATTRS.each_with_object(empty_course_record) do |attr, total|
+        sum = course_records
+          .collect { |record| record.send(attr) }
+          .compact
+          .sum
+        total.send(:"#{attr}=", sum)
+      end
+    end
+
+    def select_clause
+      columns = ["MIN(event_course_records.year) AS year",
+        "MIN(event_course_records.kursart) AS kursart",
+        "MIN(events.fachkonzept) AS fachkonzept",
+        "MIN(event_course_records.event_id) AS event_id"]
+      columns.concat(sql_summed_attrs)
+      columns << sql_sum_unterkunft
+      columns.join(", ")
+    end
+
+    def sql_summed_attrs
+      COUNTS.map { |sym| "SUM(#{sym}) AS #{sym}" }
+    end
+
+    def sql_sum_unterkunft
+      quoted_true_value = ActiveRecord::Type::Boolean.new.serialize(true)
+      "SUM(CASE WHEN event_course_records.spezielle_unterkunft = #{quoted_true_value} " \
+      "THEN event_course_records.anzahl_kurse ELSE 0 END) " \
+      "AS anzahl_spezielle_unterkunft"
+    end
+  end
+end

--- a/app/domain/fp2024/course_reporting/client_statistics.rb
+++ b/app/domain/fp2024/course_reporting/client_statistics.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2020-2022, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+# siehe auch Fp2015::CourseReporting::ClientStatistics
+module Fp2024::CourseReporting
+  class ClientStatistics
+    attr_reader :year
+
+    def initialize(year)
+      @year = year
+    end
+
+    def groups
+      load_groups.to_a
+    end
+
+    def group_canton_count(group_id, canton, leistungskategorie, fachkonzept)
+      group_participants(group_id, leistungskategorie, fachkonzept)
+        .send(canton.to_sym)
+        .to_i
+    end
+
+    def group_participants(group_id, leistungskategorie, fachkonzept)
+      group_canton_participants
+        .fetch(group_id, {})
+        .fetch(leistungskategorie, {})
+        .fetch(fachkonzept, GroupCantonParticipant.new)
+    end
+
+    def cantons
+      Event::ParticipationCantonCount.column_names - %w[id]
+    end
+
+    private
+
+    def load_groups
+      @load_groups ||= Group.by_bsv_number.all
+    end
+
+    GroupCantonParticipant = Struct.new(
+      :group_id, :leistungskategorie, :fachkonzept,
+      :course_count, :course_hours, :other_attendees,
+      :ag, :ai, :ar, :be, :bl, :bs, :fr, :ge, :gl, :gr, :ju, :lu, :ne, :nw,
+      :ow, :sg, :sh, :so, :sz, :tg, :ti, :ur, :vd, :vs, :zg, :zh, :another
+    ) do
+      def total
+        [
+          :ag, :ai, :ar, :be, :bl, :bs, :fr, :ge, :gl, :gr, :ju, :lu, :ne, :nw,
+          :ow, :sg, :sh, :so, :sz, :tg, :ti, :ur, :vd, :vs, :zg, :zh, :another
+        ].map { |canton| send(canton).to_i }.sum
+      end
+    end
+
+    def group_canton_participants
+      @group_canton_participants ||=
+        raw_group_canton_participants
+          .map { |row| GroupCantonParticipant.new(*row) }
+          .each_with_object({}) do |gcp, memo|
+          memo[gcp.group_id] ||= {}
+          memo[gcp.group_id][gcp.leistungskategorie] ||= {}
+          memo[gcp.group_id][gcp.leistungskategorie][gcp.fachkonzept] = gcp
+        end
+    end
+
+    def group_canton_participants_relation # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
+      columns = [
+        "MAX(groups.id) AS group_id",
+        "events.leistungskategorie AS event_leistungskategorie"
+      ]
+
+      fachkonzepte = {
+        freizeit_jugend: "sport",
+        freizeit_erwachsen: "sport",
+        sport_jugend: "sport",
+        sport_erwachsen: "sport",
+        autonomie_foerderung: "weiterbildung",
+        treffpunkt: "treffpunkt"
+      }.map do |fachkonzept, kursinhalt|
+        "WHEN '#{fachkonzept}' THEN '#{kursinhalt}'"
+      end
+
+      columns << "CASE events.fachkonzept #{fachkonzepte.join(" ")} " \
+                 "ELSE events.fachkonzept END AS event_fachkonzept"
+
+      columns << "SUM(event_course_records.anzahl_kurse) AS course_count"
+
+      columns << <<~SQL.split("\n").map(&:strip).join(" ") # total_tage_teilnehmende
+        CASE events.leistungskategorie
+        WHEN 'tp' THEN SUM(COALESCE(event_course_records.betreuungsstunden, 0))
+        ELSE
+          (
+            SUM(COALESCE(event_course_records.tage_behinderte, 0)) +
+            SUM(COALESCE(event_course_records.tage_angehoerige, 0))
+          )
+        END AS course_hours
+      SQL
+
+      columns << <<~SQL.split("\n").map(&:strip).join(" ")
+        CASE events.leistungskategorie
+        WHEN 'tp' THEN 0
+        ELSE
+          CASE MAX(events.type)
+          WHEN 'Event::AggregateCourse' THEN
+            SUM(COALESCE(event_course_records.tage_weitere, 0))
+          ELSE
+            SUM(
+              (
+                COALESCE(event_course_records.teilnehmende_weitere, 0) *
+                event_course_records.kursdauer
+              ) - COALESCE(event_course_records.absenzen_weitere, 0)
+            )
+          END
+        END AS other_attendees
+      SQL
+
+      cantons.each do |canton|
+        columns << "SUM(COALESCE(event_participation_canton_counts.#{canton}, 0)) " \
+                   " + " \
+                   "SUM(COALESCE(affiliated_canton_counts_event_course_records.#{canton}, 0)) " \
+                   "#{canton}"
+      end
+
+      Event::CourseRecord
+        .select(columns.join(", "))
+        .where(year: @year, subventioniert: true)
+        .left_joins(event: [:groups])
+        .left_joins(:challenged_canton_count, :affiliated_canton_count)
+        .group("group_id, event_leistungskategorie, event_fachkonzept")
+    end
+
+    def raw_group_canton_participants
+      ActiveRecord::Base.connection.select_rows(group_canton_participants_relation.to_sql)
+    end
+  end
+end

--- a/app/domain/fp2024/event/course_record/calculation.rb
+++ b/app/domain/fp2024/event/course_record/calculation.rb
@@ -1,0 +1,191 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2020-2021, Insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024
+  class Event::CourseRecord::Calculation
+    attr_reader :record
+
+    def initialize(record)
+      @record = record
+    end
+
+    # rubocop:disable Layout/EmptyLinesAroundArguments
+    delegate :inputkriterien,
+      :subventioniert,
+      :kursart,
+      :kursdauer,
+      :teilnehmende_behinderte,
+      :teilnehmende_angehoerige,
+      :teilnehmende_weitere,
+      :absenzen_behinderte,
+      :absenzen_angehoerige,
+      :absenzen_weitere,
+      :leiterinnen,
+      :fachpersonen,
+      :hilfspersonal_ohne_honorar,
+      :hilfspersonal_mit_honorar,
+      :kuechenpersonal,
+      :honorare_inkl_sozialversicherung,
+      :unterkunft,
+      :uebriges,
+      :beitraege_teilnehmende,
+      :spezielle_unterkunft,
+      :year,
+      :teilnehmende_mehrfachbehinderte,
+      :direkter_aufwand,
+      :gemeinkostenanteil,
+      :gemeinkosten_updated_at,
+      :zugeteilte_kategorie,
+      :challenged_canton_count_id,
+      :affiliated_canton_count_id,
+      :anzahl_kurse,
+      :tage_behinderte,
+      :tage_angehoerige,
+      :tage_weitere,
+      :betreuerinnen,
+      :betreuungsstunden,
+
+      :event,
+      :challenged_canton_count,
+      :affiliated_canton_count,
+
+      :anzahl_spezielle_unterkunft,
+      to: :record
+    # rubocop:enable Layout/EmptyLinesAroundArguments
+
+    ::Event::Reportable::LEISTUNGSKATEGORIEN.each do |kategorie|
+      delegate :"#{kategorie}?", to: :record
+    end
+
+    def total_absenzen
+      absenzen_behinderte.to_d +
+        absenzen_angehoerige.to_d +
+        absenzen_weitere.to_d
+    end
+
+    def teilnehmende
+      teilnehmende_behinderte.to_i +
+        teilnehmende_angehoerige.to_i +
+        teilnehmende_weitere.to_i
+    end
+
+    def betreuende
+      if tp?
+        betreuerinnen.to_i
+      else
+        leiterinnen.to_i +
+          fachpersonen.to_i +
+          hilfspersonal_mit_honorar.to_i +
+          hilfspersonal_ohne_honorar.to_i
+      end
+    end
+
+    def total_tage_teilnehmende
+      tage_behinderte.to_d +
+        tage_angehoerige.to_d +
+        tage_weitere.to_d
+    end
+
+    def praesenz_prozent
+      if total_tage_teilnehmende.positive?
+        ((total_tage_teilnehmende / (total_tage_teilnehmende + total_absenzen)) * 100).round
+      else
+        100
+      end
+    end
+
+    def betreuungsschluessel
+      if betreuende.to_d.positive?
+        teilnehmende_behinderte.to_d / betreuende.to_d
+      else
+        0
+      end
+    end
+
+    def total_vollkosten
+      direkter_aufwand.to_d +
+        gemeinkostenanteil.to_d
+    end
+
+    def direkte_kosten_pro_le
+      if total_tage_teilnehmende.positive?
+        direkter_aufwand.to_d / total_tage_teilnehmende
+      else
+        0
+      end
+    end
+
+    def direkte_kosten_pro_betreuungsstunde
+      if betreuungsstunden.to_d.positive?
+        direkter_aufwand.to_d / betreuungsstunden.to_d
+      else
+        0
+      end
+    end
+
+    def vollkosten_pro_le
+      if total_tage_teilnehmende.positive?
+        total_vollkosten / total_tage_teilnehmende
+      else
+        0
+      end
+    end
+
+    def vollkosten_pro_betreuungsstunde
+      if betreuungsstunden.to_d.positive?
+        total_vollkosten / betreuungsstunden.to_d
+      else
+        0
+      end
+    end
+
+    def duration_in_days?
+      !duration_in_hours?
+    end
+
+    def duration_in_hours?
+      sk? || tp?
+    end
+
+    def set_cached_values
+      @record.teilnehmende_behinderte = challenged_canton_count&.total
+      @record.teilnehmende_angehoerige = affiliated_canton_count&.total
+      @record.direkter_aufwand = calculate_direkter_aufwand
+
+      unless event.is_a?(::Event::AggregateCourse)
+        @record.betreuungsstunden = calculate_betreuungsstunden
+        @record.tage_behinderte = calculate_tage_behinderte
+        @record.tage_angehoerige = calculate_tage_angehoerige
+        @record.tage_weitere = calculate_tage_weitere
+      end
+    end
+
+    private
+
+    def calculate_direkter_aufwand
+      honorare_inkl_sozialversicherung.to_d +
+        unterkunft.to_d +
+        uebriges.to_d
+    end
+
+    def calculate_tage_behinderte
+      (kursdauer.to_d * teilnehmende_behinderte.to_i) - absenzen_behinderte.to_d
+    end
+
+    def calculate_tage_angehoerige
+      (kursdauer.to_d * teilnehmende_angehoerige.to_i) - absenzen_angehoerige.to_d
+    end
+
+    def calculate_tage_weitere
+      (kursdauer.to_d * teilnehmende_weitere.to_i) - absenzen_weitere.to_d
+    end
+
+    def calculate_betreuungsstunden
+      (kursdauer.to_d * betreuende)
+    end
+  end
+end

--- a/app/domain/fp2024/export/pdf/cost_accounting.rb
+++ b/app/domain/fp2024/export/pdf/cost_accounting.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2016-2017 Insieme Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::Export::Pdf
+  class CostAccounting < ::Export::Tabular::Base
+    include CostAccounting::Style
+    include Featureperioden::Domain
+
+    attr_accessor :year
+
+    COLSPANS = {22 => [0, 1, 2, 3, 4, 5, 6, 7],
+                23 => [0, 1, 2]}.freeze
+
+    self.row_class = Export::Pdf::CostAccounting::Row
+
+    def initialize(list, group_name, year)
+      @list = list
+      @group_name = group_name
+      @year = year
+    end
+
+    def generate
+      pdf = Prawn::Document.new(page_size: "A4", page_layout: :landscape)
+      style_pdf(pdf)
+
+      add_header(pdf)
+      pdf.move_down 30
+      cost_accounting_table(pdf)
+      pdf.render
+    end
+
+    private
+
+    def cost_accounting_table(pdf)
+      data = [labels] + data_rows
+      pdf.table(data) do |t|
+        style_table(t)
+      end
+    end
+
+    def data_rows
+      @list.collect.with_index do |entry, row|
+        row_content = []
+        values(entry).each_with_index do |value, cell|
+          next if skip_cell?(row, cell)
+
+          row_content << cell_value(row, cell, value)
+        end
+        row_content
+      end
+    end
+
+    def cell_value(row, cell, value)
+      colspan_cell?(row, cell) ? colspan_cell(row, value) : value
+    end
+
+    def skip_cell?(row, cell)
+      return false unless COLSPANS.has_key?(row)
+      return false if colspan_cell?(row, cell)
+
+      COLSPANS[row].include?(cell)
+    end
+
+    def colspan_cell?(row, cell)
+      return false unless COLSPANS.has_key?(row)
+
+      COLSPANS[row].first == cell
+    end
+
+    def colspan_cell(row, value)
+      colspan_length = COLSPANS[row].count
+      {content: value, colspan: colspan_length}
+    end
+
+    def add_header(pdf)
+      pdf.draw_text(@group_name, at: [0, 500], size: 9)
+      pdf.draw_text("#{I18n.t("cost_accounting.index.reporting_year")}: #{@year}",
+        at: [300, 500],
+        size: 9)
+      pdf.draw_text(printed_at, at: [680, 500])
+    end
+
+    def printed_at
+      date = I18n.l(Time.zone.today)
+      time = Time.zone.now.strftime(" %H:%M")
+      "Druck:   #{date} #{time}"
+    end
+
+    def human(field)
+      I18n.t("activerecord.attributes.cost_accounting_record.#{field}")
+    end
+
+    def build_attribute_labels
+      {}.tap do |labels|
+        labels[:report] = human(:report)
+
+        fp_class("CostAccounting::Table").fields.each do |field|
+          labels[field.to_sym] = human(field)
+        end
+      end
+    end
+  end
+end

--- a/app/domain/fp2024/export/pdf/cost_accounting/style.rb
+++ b/app/domain/fp2024/export/pdf/cost_accounting/style.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2016, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+#
+
+module Fp2024::Export::Pdf::CostAccounting::Style
+  COLORED_ROWS = [0, 5, 8, 9, 10, 16, 18].freeze
+  CUSTOM_WIDTH_COLUMNS = [].freeze
+
+  def style_pdf(pdf)
+    pdf.font "Helvetica", size: 6
+  end
+
+  def style_table(table)
+    table.column(1..16).align = :center
+    table.column(1..16).padding_left = 2
+    table.column(1..16).padding_right = 2
+    table.column(0).width = 210
+    cell_style(table)
+    color_table(table)
+    align_header(table)
+    table_width(table)
+  end
+
+  private
+
+  def cell_style(table)
+    table.cells.border_width = 0.5
+    table.cells.height = 14
+    table.cells.padding_top = 2
+    table.cells.overflow = :ellipse
+  end
+
+  def color_table(table)
+    COLORED_ROWS.each do |row_index|
+      table.row(row_index).background_color = "BBBBBB"
+    end
+  end
+
+  def align_header(table)
+    header_row = table.cells.row(0)
+    header_row.content_width = 200
+    header_row.rotate = 90
+    header_row.rotate_around = :center
+    header_row.align = :left
+    header_row.height = 80
+    header_row.width = 24
+    header_row.padding_top = -5
+    header_row.padding_left = 12
+  end
+
+  def table_width(table)
+    CUSTOM_WIDTH_COLUMNS.each do |column_index|
+      table.column(column_index).width = 8
+      table.column(column_index).row(1..26).content = ""
+      table.column(column_index).row(0).padding_left = 3
+    end
+  end
+end

--- a/app/domain/fp2024/export/tabular/cost_accounting/list.rb
+++ b/app/domain/fp2024/export/tabular/cost_accounting/list.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2020 Insieme Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::Export::Tabular::CostAccounting
+  class List < Export::Tabular::Base
+    include Featureperioden::Domain
+
+    attr_accessor :year
+
+    self.row_class = Export::Tabular::CostAccounting::Row
+    self.auto_filter = false
+
+    def initialize(list, group_name, year)
+      @group_name = group_name
+      @year = year
+      @list = only_visible_reports(list)
+      self.model_class = fp_class("CostAccounting::Report::Base")
+      add_header_rows
+    end
+
+    def build_attribute_labels
+      {}.tap do |labels|
+        labels[:report] = human(:report)
+
+        fp_class("CostAccounting::Table").fields.each do |field|
+          labels[field.to_sym] = human(field)
+        end
+      end
+    end
+
+    private
+
+    def only_visible_reports(reports)
+      visible_report_keys = Fp2024::CostAccounting::Table::VISIBLE_REPORTS.map(&:key)
+
+      reports.select do |report|
+        visible_report_keys.include?(report.key)
+      end
+    end
+
+    def human(field)
+      I18n.t("activerecord.attributes.cost_accounting_record.#{field}")
+    end
+
+    def add_header_rows
+      header_rows << []
+      header_rows << title_header_values
+      header_rows << []
+      header_rows << combined_labels_row
+    end
+
+    def title_header_values
+      row = Array.new(18)
+      row[0] = @group_name
+      row[1] = reporting_year
+      row[14] = "#{I18n.t("global.printed")}: "
+      row[15] = printed_at
+      row
+    end
+
+    def combined_labels_row
+      row = Array.new(18)
+      row[5] = I18n.t("cost_accounting.index.gemeinkosten")
+      row
+    end
+
+    def reporting_year
+      "#{I18n.t("cost_accounting.index.reporting_year")}: #{@year}"
+    end
+
+    def printed_at
+      I18n.l(Time.zone.today) + Time.zone.now.strftime(" %H:%M")
+    end
+  end
+end

--- a/app/domain/fp2024/export/tabular/cost_accounting/pro_verein.rb
+++ b/app/domain/fp2024/export/tabular/cost_accounting/pro_verein.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2021, Insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::Export::Tabular::CostAccounting
+  class ProVerein
+    include Featureperioden::Domain
+
+    class << self
+      def csv(stats)
+        Export::Csv::Generator.new(new(stats)).call
+      end
+    end
+
+    delegate :year, to: :stats
+
+    attr_reader :stats
+
+    # Fp2024::CostAccounting::ProVerein
+    def initialize(stats)
+      @stats = stats
+    end
+
+    def labels
+      empty_row
+    end
+
+    def data_rows(_format = :csv)
+      return enum_for(:data_rows) unless block_given?
+
+      @stats.vereine.each do |group|
+        yield group_row(group)
+        yield label_row
+        @stats.data_for(group).each do |row_label, row_data|
+          yield data_row(row_label, row_data)
+        end
+
+        4.times { yield empty_row }
+      end
+    end
+
+    private
+
+    def label_keys
+      @label_keys ||= [:type] + @stats.class::CostAccountingRow.empty_row.members
+    end
+
+    def empty_row
+      Array.new(label_keys.size, nil)
+    end
+
+    def label_row
+      label_keys.map { |key| fp_t(key) }
+    end
+
+    def group_row(group)
+      [group.name, group.bsv_number, *Array.new(label_keys.count - 2, nil)]
+    end
+
+    def data_row(row_label, row_data)
+      [fp_t(row_label), *row_data.members.map { |attr| row_data.send(attr) }]
+    end
+
+    def fp_t(field, options = {})
+      I18n.t(field, **options.merge(scope: fp_i18n_scope("cost_accounting.pro_verein")))
+    end
+  end
+end

--- a/app/domain/fp2024/export/tabular/course_reporting/aggregation.rb
+++ b/app/domain/fp2024/export/tabular/course_reporting/aggregation.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2020 Insieme Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::Export
+  module Tabular
+    module CourseReporting
+      class Aggregation
+        include Featureperioden::Domain
+
+        # rubocop:disable Style/SymbolArray
+        NON_TP_ATTRIBUTES = %i[
+          anzahl_kurse kursdauer
+
+          teilnehmende teilnehmende_behinderte teilnehmende_angehoerige teilnehmende_weitere
+
+          total_absenzen absenzen_behinderte absenzen_angehoerige absenzen_weitere
+
+          total_tage_teilnehmende tage_behinderte tage_angehoerige tage_weitere
+
+          betreuende leiterinnen fachpersonen hilfspersonal_ohne_honorar hilfspersonal_mit_honorar
+          kuechenpersonal direkter_aufwand honorare_inkl_sozialversicherung unterkunft uebriges
+
+          direkte_kosten_pro_le total_vollkosten vollkosten_pro_le beitraege_teilnehmende
+          betreuungsschluessel anzahl_spezielle_unterkunft
+        ].freeze
+
+        TP_ATTRIBUTES = %i[
+          anzahl_kurse kursdauer
+
+          teilnehmende teilnehmende_behinderte teilnehmende_angehoerige teilnehmende_weitere
+
+          betreuungsstunden
+
+          betreuende direkter_aufwand honorare_inkl_sozialversicherung unterkunft uebriges
+
+          direkte_kosten_pro_betreuungsstunde total_vollkosten vollkosten_pro_betreuungsstunde
+          beitraege_teilnehmende betreuungsschluessel
+        ].freeze
+        # rubocop:enable Style/SymbolArray
+
+        class << self
+          # aggregation is Fp2024::CourseReporting::Aggregation
+          # values also come from Event::CourseRecord
+          def csv(aggregation)
+            Export::Csv::Generator.new(new(aggregation)).call
+          end
+        end
+
+        attr_reader :aggregation
+        delegate :year, to: :aggregation
+
+        def initialize(aggregation)
+          @aggregation = aggregation
+        end
+
+        def data_rows(_format = nil)
+          return enum_for(:data_rows) unless block_given?
+
+          attributes_of_leistungskategorie.each do |attr|
+            yield attributes(attr)
+          end
+        end
+
+        def labels
+          values("") do |kriterium, kursart|
+            if kriterium == "all"
+              kursart_label(kursart)
+            else
+              I18n.t("activerecord.attributes.event/course.fachkonzepte.#{kriterium}")
+            end
+          end
+        end
+
+        private
+
+        def fp_translation(attr)
+          scope = fp_i18n_scope("course_reporting.aggregations")
+          if treffpunkt?
+            I18n.t("#{attr}_tp", scope: scope, default: [attr.to_sym, t(attr)])
+          elsif abrechnung_in_stunden?
+            I18n.t("#{attr}_stunden", scope: scope, default: [attr.to_sym, t(attr)])
+          else
+            I18n.t(attr, scope: scope, default: t(attr))
+          end
+        end
+
+        def t(attr)
+          if abrechnung_in_stunden?
+            I18n.t("course_reporting.aggregations.#{attr}_stunden",
+              default: :"course_reporting.aggregations.#{attr}")
+          else
+            I18n.t("course_reporting.aggregations.#{attr}")
+          end
+        end
+
+        def kursart_label(kursart)
+          if kursart == "total"
+            I18n.t("course_reporting.aggregations.total")
+          else
+            I18n.t("activerecord.attributes.event/course_record.kursarten.#{kursart}")
+          end
+        end
+
+        def attributes_of_leistungskategorie
+          return TP_ATTRIBUTES if treffpunkt?
+
+          NON_TP_ATTRIBUTES
+        end
+
+        def attributes(attr)
+          values(fp_translation(attr)) do |kriterium, kursart|
+            aggregation.course_counts(kriterium, kursart, attr)
+          end
+        end
+
+        def values(label)
+          [label].tap do |result|
+            each_column do |kriterium, kursart|
+              result << yield(kriterium, kursart)
+            end
+          end
+        end
+
+        def each_column(&)
+          kriterien
+            .product(kursarten)
+            .append(%w[all total])
+            .each(&)
+        end
+
+        def kriterien
+          return [] if treffpunkt?
+
+          aggregation.kursfachkonzepte
+        end
+
+        def kursarten
+          return aggregation.kursarten if treffpunkt?
+
+          aggregation.kursarten + %w[total]
+        end
+
+        def blockkurs?
+          aggregation.leistungskategorie == "bk"
+        end
+
+        def tageskurs?
+          aggregation.leistungskategorie == "tk"
+        end
+
+        def jahreskurs?
+          aggregation.leistungskategorie == "sk"
+        end
+
+        def treffpunkt?
+          aggregation.leistungskategorie == "tp"
+        end
+
+        def abrechnung_in_stunden?
+          jahreskurs? || treffpunkt?
+        end
+      end
+    end
+  end
+end

--- a/app/domain/fp2024/export/tabular/course_reporting/client_statistics.rb
+++ b/app/domain/fp2024/export/tabular/course_reporting/client_statistics.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2020-2021, Insieme Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+# see also Fp2015::Export::Tabular::CourseReporting::ClientStatistics
+module Fp2024::Export
+  module Tabular
+    module CourseReporting
+      class ClientStatistics
+        include Featureperioden::Domain
+
+        class << self
+          def csv(stats)
+            Export::Csv::Generator.new(new(stats)).call
+          end
+        end
+
+        delegate :year, to: :stats
+
+        attr_reader :stats
+
+        # Fp2024::CourseReporting::ClientStatistics
+        def initialize(stats)
+          @stats = stats
+        end
+
+        def data_rows(_format = :csv) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
+          return enum_for(:data_rows) unless block_given?
+
+          @stats.groups.each do |group|
+            yield group_label(group)
+            yield group_stats(group.id, "sk", "weiterbildung")
+            yield group_stats(group.id, "sk", "sport")
+            yield group_stats(group.id, "bk", "weiterbildung")
+            yield group_stats(group.id, "bk", "sport")
+            yield group_stats(group.id, "tk", "weiterbildung")
+            yield group_stats(group.id, "tk", "sport")
+            yield group_stats(group.id, "tp", "treffpunkt")
+            yield empty_row
+          end
+        end
+
+        def labels
+          [
+            fp_t("group_or_course_type"),
+            fp_t("course_fachkonzept"),
+            fp_t("course_count"),
+            fp_t("course_hours"),
+            fp_t("other_attendees"),
+            fp_t("course_total")
+          ] + @stats.cantons.map do |canton|
+            attr_t("event/participation_canton_count.#{canton}")
+          end
+        end
+
+        private
+
+        def empty_row
+          Array.new(stats.cantons.size + 6, nil)
+        end
+
+        def group_label(group)
+          [group.name, group.bsv_number, nil, nil, nil, nil] + stats.cantons.map { |_| nil }
+        end
+
+        def group_stats(group_id, lk, fachkonzept) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
+          gcp = stats.group_participants(group_id, lk, fachkonzept)
+          [
+            attr_t("event/course.leistungskategorien.#{lk}", count: 3),
+            fp_t("fachkonzept.#{fachkonzept}"),
+            gcp.course_count.presence,
+            course_hours_including_grundlagen_hours(gcp),
+            maybe_zero(gcp.other_attendees.to_i),
+            maybe_zero(gcp.total.to_i)
+          ] + stats.cantons.map do |canton|
+            maybe_zero(gcp.send(canton.to_sym).to_i)
+          end
+        end
+
+        def course_hours_including_grundlagen_hours(gcp)
+          grundlagen_field = if gcp.fachkonzept == "treffpunkt"
+            :treffpunkte_grundlagen
+          else
+            :kurse_grundlagen
+          end
+
+          grundlagen_hours = ::TimeRecord.where(
+            group_id: gcp.group_id, year: year,
+            type: %w[TimeRecord::EmployeeTime TimeRecord::VolunteerWithVerificationTime]
+          ).sum(grundlagen_field).to_f
+
+          maybe_zero(gcp.course_hours.to_f + grundlagen_hours)
+        end
+
+        def maybe_zero(number)
+          number.zero? ? nil : number
+        end
+
+        def fp_t(field, options = {})
+          I18n.t(field, **options.merge(scope: fp_i18n_scope("course_reporting.client_statistics")))
+        end
+
+        def attr_t(attr, options = {})
+          I18n.t(attr, **options.merge(scope: "activerecord.attributes"))
+        end
+      end
+    end
+  end
+end

--- a/app/domain/fp2024/export/tabular/events/aggregate_course/detail_list.rb
+++ b/app/domain/fp2024/export/tabular/events/aggregate_course/detail_list.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2014-2020 Insieme Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::Export::Tabular::Events
+  class AggregateCourse::DetailList < DetailList
+    def title_header_values
+      row = Array.new(39)
+      row[0] = @group_name
+      row[2] = reporting_year
+      row[7] = document_title
+      row[28] = "#{I18n.t("global.printed")}: "
+      row[31] = printed_at
+      row
+    end
+
+    def title
+      I18n.t("activerecord.models.event/aggregate_course.other")
+    end
+
+    # rubocop:disable Layout/EmptyLineBetweenDefs
+    def add_date_labels(_labels)
+    end
+    def add_contact_labels(_labels)
+    end
+    def add_additional_labels(_labels)
+    end
+    def add_count_labels(_labels)
+    end
+    # rubocop:enable Layout/EmptyLineBetweenDefs
+  end
+end

--- a/app/domain/fp2024/export/tabular/events/aggregate_course/short_list.rb
+++ b/app/domain/fp2024/export/tabular/events/aggregate_course/short_list.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2014-2020 Insieme Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::Export::Tabular::Events
+  class AggregateCourse::ShortList < ShortList
+    def title_header_values
+      row = Array.new(20)
+      row[0] = @group_name
+      row[2] = reporting_year
+      row[10] = document_title
+      row[17] = "#{I18n.t("global.printed")}: "
+      row[19] = printed_at
+      row
+    end
+
+    def title
+      I18n.t("activerecord.models.event/aggregate_course.other")
+    end
+
+    # rubocop:disable Layout/EmptyLineBetweenDefs
+    def add_date_labels(_labels)
+    end
+    def add_contact_labels(_labels)
+    end
+    def add_additional_labels(_labels)
+    end
+    def add_count_labels(_labels)
+    end
+    # rubocop:enable Layout/EmptyLineBetweenDefs
+  end
+end

--- a/app/domain/fp2024/export/tabular/events/detail_list.rb
+++ b/app/domain/fp2024/export/tabular/events/detail_list.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2014-2020 Insieme Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::Export::Tabular::Events
+  class DetailList < ::Export::Tabular::Events::List
+    def initialize(list, group_name, year)
+      @group_name = group_name
+      @year = year
+      @list = list
+      add_header_rows
+    end
+
+    COURSE_RECORD_ATTRS = [
+      :kursdauer,
+      ## effektiv teilnehmende
+      :teilnehmende_behinderte, :teilnehmende_mehrfachbehinderte,
+      :teilnehmende_angehoerige, :teilnehmende_weitere,
+      ## absenztage
+      :absenzen_behinderte, :absenzen_angehoerige, :absenzen_weitere,
+      ## total teilnehmerinnentage
+      :tage_behinderte, :tage_angehoerige, :tage_weitere,
+      ## total betreuungsstunden
+      :betreuungsstunden,
+      ## betreuerinnen
+      :leiterinnen, :fachpersonen,
+      :hilfspersonal_mit_honorar, :hilfspersonal_ohne_honorar,
+      :betreuerinnen,
+      ## personal ohne betreuungsfunktion
+      :kuechenpersonal,
+      ## direkter aufwand
+      :honorare_inkl_sozialversicherung, :unterkunft, :uebriges,
+      :direkter_aufwand,
+      # ertrag
+      :beitraege_teilnehmende,
+      # auswertungen
+      :gemeinkostenanteil, :total_vollkosten,
+      :total_tage_teilnehmende, :vollkosten_pro_le
+    ].freeze
+
+    self.row_class = Export::Tabular::Events::DetailRow
+
+    private
+
+    def build_attribute_labels
+      super.tap do |labels|
+        add_additional_course_record_labels(labels)
+        remove_course_record_label(labels, :inputkriterien)
+        remove_course_record_label(labels, :kursart)
+      end
+    end
+
+    def add_additional_course_record_labels(labels)
+      COURSE_RECORD_ATTRS.each do |attr|
+        add_course_record_label(labels, attr)
+      end
+    end
+
+    def add_header_rows
+      header_rows << []
+      header_rows << title_header_values
+      header_rows << []
+    end
+
+    def title_header_values
+      row = Array.new(71)
+      row[0] = @group_name
+      row[3] = reporting_year
+      row[12] = document_title
+      row[63] = "#{I18n.t("global.printed")}: "
+      row[67] = printed_at
+      row
+    end
+
+    def document_title
+      "#{I18n.t("event.lists.courses.xlsx_export_title")}: #{title}"
+    end
+
+    def title
+      I18n.t("export/tabular/events.title")
+    end
+
+    def reporting_year
+      "#{I18n.t("cost_accounting.index.reporting_year")}: #{@year}"
+    end
+
+    def printed_at
+      I18n.l(Time.zone.today) + Time.zone.now.strftime(" %H:%M")
+    end
+  end
+end

--- a/app/domain/fp2024/export/tabular/events/short_list.rb
+++ b/app/domain/fp2024/export/tabular/events/short_list.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2014-2020 Insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::Export::Tabular::Events
+  class ShortList < ::Export::Tabular::Events::List
+    def initialize(list, group_name, year)
+      @group_name = group_name
+      @year = year
+      @list = list
+      add_header_rows
+    end
+
+    private
+
+    def build_attribute_labels
+      super.tap { |labels| }
+    end
+
+    def add_header_rows
+      header_rows << []
+      header_rows << title_header_values
+      header_rows << []
+    end
+
+    def title_header_values
+      row = Array.new(30)
+      row[0] = @group_name
+      row[3] = reporting_year
+      row[12] = document_title
+      row[29] = "#{I18n.t("global.printed")}: "
+      row[30] = printed_at
+      row
+    end
+
+    def document_title
+      "#{I18n.t("event.lists.courses.xlsx_export_title")}: #{title}"
+    end
+
+    def title
+      I18n.t("export/tabular/events.title")
+    end
+
+    def reporting_year
+      "#{I18n.t("cost_accounting.index.reporting_year")}: #{@year}"
+    end
+
+    def printed_at
+      I18n.l(Time.zone.today) + Time.zone.now.strftime(" %H:%M")
+    end
+  end
+end

--- a/app/domain/fp2024/export/tabular/statistics/group_figures.rb
+++ b/app/domain/fp2024/export/tabular/statistics/group_figures.rb
@@ -1,0 +1,212 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2014-2023, Insieme Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::Export
+  module Tabular
+    module Statistics
+      class GroupFigures
+        include Featureperioden::Domain
+        delegate :year, to: :figures
+
+        class << self
+          def csv(figures)
+            Export::Csv::Generator.new(new(figures)).call
+          end
+        end
+
+        attr_reader :figures
+
+        # See Fp2024::Statistics::GroupFigures
+        def initialize(figures)
+          @figures = figures
+        end
+
+        def data_rows(_format = nil)
+          return enum_for(:data_rows) unless block_given?
+
+          figures.groups.each do |group|
+            yield values(group)
+          end
+        end
+
+        def labels
+          labels = [t("name"), t("canton"), t("vid"), t("bsv")]
+          append_course_labels(labels)
+          append_time_labels(labels)
+          append_fte_labels(labels)
+          append_cost_accounting_labels(labels)
+          labels
+        end
+
+        private
+
+        def append_course_labels(labels) # rubocop:disable Metrics/MethodLength
+          iterate_courses do |lk, fk|
+            lk_label = t("leistungskategorie_#{lk}")
+            fk_label = I18n.t("activerecord.attributes.event/course.fachkonzepte.#{fk}")
+            labels << fp_t("anzahl_kurse", leistungskategorie: lk_label, fachkonzept: fk_label)
+            labels << fp_t("total_vollkosten", leistungskategorie: lk_label, fachkonzept: fk_label)
+            labels << fp_t("tage_behinderte", leistungskategorie: lk_label, fachkonzept: fk_label)
+            labels << fp_t("tage_angehoerige", leistungskategorie: lk_label, fachkonzept: fk_label)
+            labels << fp_t("tage_weitere", leistungskategorie: lk_label, fachkonzept: fk_label)
+            labels << fp_t("tage_total", leistungskategorie: lk_label, fachkonzept: fk_label)
+            if lk == "tp"
+              labels << fp_t("betreuungsstunden_total", leistungskategorie: lk_label, fachkonzept: fk_label) # rubocop:disable Layout/LineLength
+            end
+          end
+        end
+
+        def append_time_labels(labels) # rubocop:disable Metrics/MethodLength
+          %w[employees volunteers].each do |type|
+            %w[kurse treffpunkte].each do |section|
+              labels << fp_label("#{section}_grundlagen", "fields_full", fp_t("hours_#{type}"))
+            end
+            %w[grundlagen promoting general specific].each do |section|
+              labels << fp_label("lufeb_#{section}", "lufeb_fields_full", t("lufeb_hours_#{type}"))
+            end
+            %w[media_grundlagen total_media beratung].each do |section|
+              labels << fp_label(section, "fields_full", fp_t("hours_#{type}"))
+            end
+          end
+          labels << t("lufeb_hours_volunteers_without")
+          labels << fp_label("beratung", "fields_full", fp_t("hours_volunteers_without"))
+        end
+
+        def append_fte_labels(labels)
+          labels << t("fte_employees_total")
+          labels << t("fte_employees_only_art_74")
+          labels << t("fte_volunteers_total")
+          labels << t("fte_volunteers_only_art_74")
+          labels << t("fte_volunteers_with_verification_only_art_74")
+        end
+
+        def append_cost_accounting_labels(labels)
+          labels << t("geschluesseltes_kapitalsubstrat")
+          labels << t("faktor_kapitalsubstrat")
+          labels << t("total_aufwand")
+          labels << t("vollkosten_nach_umlagen_betrieb")
+          labels << t("iv_beitrag")
+          labels << t("deckungsbeitrag_4")
+          labels << t("iv_finanzierungsgrad_current", year: year)
+        end
+
+        def values(group) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+          values = [group.full_name.presence || group.name,
+            group.canton_label,
+            group.vid,
+            group.bsv_number]
+
+          iterate_courses do |lk, fk|
+            append_course_values(values, figures.course_record(group, lk, fk), lk)
+          end
+
+          append_time_values(values, figures.employee_time(group))
+          append_time_values(values, figures.volunteer_with_verification_time(group))
+
+          values << figures.volunteer_without_verification_time(group).try(:total_lufeb).to_i
+          values << figures.volunteer_without_verification_time(group).try(:beratung).to_i
+
+          append_employee_fte_values(values, group)
+          append_volunteer_fte_values(values, group)
+
+          append_capital_substrate_values(values, figures.capital_substrate(group))
+          append_capital_substrate_factor_values(values, figures.capital_substrate_factor(group))
+          append_cost_accounting_values(values, figures.cost_accounting_table(group))
+          append_finanzierungsgrad_values(values, figures.capital_substrate(group))
+
+          values
+        end
+
+        def append_course_values(values, record, lk = nil) # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
+          values << (record&.anzahl_kurse.to_i || 0)
+          values << (record&.total_vollkosten || 0.0)
+          values << (record&.tage_behinderte || 0.0)
+          values << (record&.tage_angehoerige || 0.0)
+          values << (record&.tage_weitere || 0.0)
+          values << (record&.total_tage_teilnehmende || 0.0)
+          values << (record&.betreuungsstunden || 0.0) if lk == "tp"
+        end
+
+        def append_time_values(values, record) # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity,Metrics/AbcSize
+          values << (record&.kurse_grundlagen || 0)
+          values << (record&.treffpunkte_grundlagen || 0)
+          values << (record&.lufeb_grundlagen || 0)
+          values << (record&.total_lufeb_promoting || 0)
+          values << (record&.total_lufeb_general || 0)
+          values << (record&.total_lufeb_specific || 0)
+          values << (record&.medien_grundlagen || 0)
+          values << (record&.total_media || 0)
+          values << (record&.beratung || 0)
+        end
+
+        def append_employee_fte_values(values, group)
+          pensum = figures.employee_pensum(group) || TimeRecord::EmployeePensum.new
+          values << pensum.total.to_d
+          values << pensum.paragraph_74.to_d
+        end
+
+        def append_volunteer_fte_values(values, group)
+          with = figures.volunteer_with_verification_time(group)
+          without = figures.volunteer_without_verification_time(group)
+          records = [with, without].compact
+
+          values << records.sum(&:total_pensum).to_d
+          values << records.sum(&:total_paragraph_74_pensum).to_d
+          values << with.try(:total_paragraph_74_pensum).to_d
+        end
+
+        def append_capital_substrate_values(values, report)
+          values << report.paragraph_74
+        end
+
+        def append_capital_substrate_factor_values(values, report)
+          values << report.paragraph_74
+        end
+
+        def append_cost_accounting_values(values, table)
+          if table
+            values << table.value_of("total_aufwand", "aufwand_ertrag_fibu")
+            values << table.value_of("vollkosten", "total")
+            values << table.value_of("beitraege_iv", "total")
+            values << table.value_of("deckungsbeitrag4", "total")
+          else
+            values << 0.0 << 0.0 << 0.0 << 0.0
+          end
+        end
+
+        def append_finanzierungsgrad_values(values, report)
+          values << (report.iv_finanzierungsgrad_current * 100)
+        end
+
+        def iterate_courses(&)
+          figures
+            .leistungskategorien
+            .product(figures.fachkonzepte)
+            .keep_if { |(lk, fk)| valid_lk_fk_combination(lk, fk) }
+            .each(&)
+        end
+
+        def valid_lk_fk_combination(lk, fk) # rubocop:disable Naming/MethodParameterName
+          (lk.to_s == "tp" && fk.to_s == "treffpunkt") ||
+            (lk.to_s != "tp" && fk.to_s != "treffpunkt")
+        end
+
+        def fp_label(section, scope, prefix)
+          fp_t(section, scope: fp_i18n_scope(scope)).prepend("#{prefix}: ")
+        end
+
+        def fp_t(field, options = {})
+          I18n.t(field, scope: fp_i18n_scope("statistics.group_figures"), **options)
+        end
+
+        def t(field, options = {})
+          I18n.t("statistics.group_figures.#{field}", **options)
+        end
+      end
+    end
+  end
+end

--- a/app/domain/fp2024/export/tabular/time_records/list.rb
+++ b/app/domain/fp2024/export/tabular/time_records/list.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2020-2022, Insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024
+  module Export
+    module Tabular
+      module TimeRecords
+        class List
+          include Featureperioden::Domain
+
+          ATTRIBUTES = [
+            :lufeb_grundlagen,
+
+            :beratung_fachhilfeorganisationen,
+            :unterstuetzung_leitorgane,
+            :freiwilligen_akquisition,
+            :total_lufeb_promoting,
+
+            :auskuenfte,
+            :referate,
+            :medien_zusammenarbeit,
+            :sensibilisierungskampagnen,
+            :total_lufeb_general,
+
+            :erarbeitung_grundlagen,
+            :gremien,
+            :vernehmlassungen,
+            :projekte,
+            :total_lufeb_specific,
+
+            :total_lufeb,
+
+            :medien_grundlagen,
+            :website,
+            :newsletter,
+            :videos,
+            :social_media,
+            :beratungsmodule,
+            :apps,
+            :total_media,
+
+            :kurse_grundlagen,
+            :blockkurse,
+            :tageskurse,
+            :jahreskurse,
+            :treffpunkte_grundlagen,
+            :treffpunkte,
+            :total_courses,
+
+            :beratung,
+            :total_additional_person_specific,
+
+            :mittelbeschaffung,
+            :verwaltung,
+            :total_remaining,
+
+            :total_paragraph_74,
+            :total_paragraph_74_pensum,
+
+            :total_not_paragraph_74,
+            :total_not_paragraph_74_pensum,
+
+            :total,
+            :total_pensum
+          ].freeze
+
+          PENSUM_ATTRIBUTES = [
+            :paragraph_74,
+            :not_paragraph_74,
+            :total
+          ].freeze
+
+          class << self
+            def csv(records)
+              ::Export::Csv::Generator.new(new(records)).call
+            end
+          end
+
+          attr_reader :records, :year
+
+          def initialize(records)
+            @records = records.index_by { |r| r.class.key }
+            @year = 2022 # hardcoded to fp2022
+          end
+
+          def data_rows(_format = nil)
+            return enum_for(:data_rows) unless block_given?
+
+            PENSUM_ATTRIBUTES.each do |attr|
+              yield pensum_attributes(attr)
+            end
+            ATTRIBUTES.each do |attr|
+              yield attributes(attr)
+            end
+          end
+
+          def labels
+            [nil,
+              ::TimeRecord::EmployeeTime.model_name.human,
+              ::TimeRecord::VolunteerWithVerificationTime.model_name.human,
+              ::TimeRecord::VolunteerWithoutVerificationTime.model_name.human]
+          end
+
+          private
+
+          def pensum_attributes(attr)
+            [::TimeRecord::EmployeePensum.human_attribute_name(attr),
+              records["employee_time"].try(:employee_pensum).try(attr),
+              nil,
+              nil]
+          end
+
+          def attributes(attr)
+            [label(::TimeRecord, attr),
+              value(::TimeRecord::EmployeeTime, attr),
+              value(::TimeRecord::VolunteerWithVerificationTime, attr),
+              value(::TimeRecord::VolunteerWithoutVerificationTime, attr)]
+          end
+
+          def label(klass, attr)
+            I18n.t(attr,
+              scope: fp_i18n_scope(klass.name.tableize),
+              default: [
+                klass.human_attribute_name(attr)
+              ])
+          end
+
+          def value(klass, attr)
+            records[klass.key].try(attr)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/domain/fp2024/export/tabular/time_records/lufeb_pro_verein.rb
+++ b/app/domain/fp2024/export/tabular/time_records/lufeb_pro_verein.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2021, Insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::Export::Tabular::TimeRecords
+  class LufebProVerein
+    include Featureperioden::Domain
+
+    class << self
+      def csv(stats)
+        Export::Csv::Generator.new(new(stats)).call
+      end
+    end
+
+    delegate :year, to: :stats
+
+    attr_reader :stats
+
+    # Fp2024::TimeRecords::LufebProVerein
+    def initialize(stats)
+      @stats = stats
+    end
+
+    def data_rows(_format = :csv)
+      return enum_for(:data_rows) unless block_given?
+
+      yield empty_row
+
+      @stats.vereine.each do |group|
+        yield group_label(group)
+        yield group_row(group, :general)
+        yield group_row(group, :specific_with_grundlagen)
+        yield group_row(group, :promoting)
+        yield empty_row
+      end
+    end
+
+    def labels
+      [fp_t("group_or_stat"), ""]
+    end
+
+    private
+
+    def group_label(group)
+      [group.name, nil]
+    end
+
+    def group_row(group, stat)
+      [fp_t(stat), send(stat, group) || 0]
+    end
+
+    def empty_row
+      [nil, nil]
+    end
+
+    def general(group)
+      @stats.lufeb_data_for(group.id).general
+    end
+
+    def promoting(group)
+      @stats.lufeb_data_for(group.id).promoting
+    end
+
+    def specific_with_grundlagen(group)
+      @stats.lufeb_data_for(group.id).to_h
+        .values_at(:specific, :lufeb_grundlagen, :kurse_grundlagen)
+        .compact
+        .sum.to_d
+    end
+
+    def fp_t(field, options = {})
+      I18n.t(field, **options.merge(scope: fp_i18n_scope("time_records.lufeb_times")))
+    end
+  end
+end

--- a/app/domain/fp2024/export/tabular/time_records/organisations_daten.rb
+++ b/app/domain/fp2024/export/tabular/time_records/organisations_daten.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2021, Insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::Export::Tabular::TimeRecords
+  class OrganisationsDaten
+    include Featureperioden::Domain
+
+    class << self
+      def csv(stats)
+        Export::Csv::Generator.new(new(stats)).call
+      end
+    end
+
+    delegate :year, to: :stats
+
+    attr_reader :stats
+
+    def initialize(stats)
+      @stats = stats
+    end
+
+    def data_rows(_format = :csv)
+      return enum_for(:data_rows) unless block_given?
+
+      yield empty_row
+
+      @stats.vereine.each do |group|
+        yield group_label(group)
+        yield group_row(group, :angestellte_insgesamt)
+        yield group_row(group, :angestellte_art_74)
+        yield group_row(group, :freiwillige_insgesamt)
+        yield group_row(group, :freiwillige_art_74)
+        yield empty_row
+      end
+    end
+
+    def labels
+      [fp_t("group_or_stat"), ""]
+    end
+
+    private
+
+    def group_label(group)
+      [group.name, nil]
+    end
+
+    def group_row(group, stat)
+      [
+        fp_t(stat),
+        @stats.data_for(group).send(stat) || 0
+      ]
+    end
+
+    def empty_row
+      [nil, nil]
+    end
+
+    def fp_t(field, options = {})
+      I18n.t(field, **options.merge(scope: fp_i18n_scope("time_records.group_data")))
+    end
+  end
+end

--- a/app/domain/fp2024/export/tabular/time_records/vereinsliste.rb
+++ b/app/domain/fp2024/export/tabular/time_records/vereinsliste.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2020 Insieme Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::Export
+  module Tabular
+    module TimeRecords
+      class Vereinsliste < Export::Tabular::Base
+        include Featureperioden::Domain
+
+        ATTRS_LUFEB = [
+          :lufeb_grundlagen,
+
+          :beratung_fachhilfeorganisationen,
+          :unterstuetzung_leitorgane,
+          :freiwilligen_akquisition,
+          :total_lufeb_promoting,
+
+          :auskuenfte,
+          :referate,
+          :medien_zusammenarbeit,
+          :sensibilisierungskampagnen,
+          :total_lufeb_general,
+
+          :erarbeitung_grundlagen,
+          :gremien,
+          :vernehmlassungen,
+          :projekte,
+          :total_lufeb_specific,
+
+          :total_lufeb,
+
+          :medien_grundlagen,
+          :website,
+          :newsletter,
+          :videos,
+          :social_media,
+          :beratungsmodule,
+          :apps,
+          :total_media
+        ].freeze
+
+        ATTRS_LUFEB_SUM = [
+          :lufeb_grundlagen,
+          :total_lufeb_promoting,
+          :total_lufeb_general,
+          :total_lufeb_specific,
+          :total_lufeb,
+          :total_media
+        ].freeze
+
+        ATTRS_GENERAL = [
+          :kurse_grundlagen,
+          :blockkurse,
+          :tageskurse,
+          :jahreskurse,
+          :treffpunkte_grundlagen,
+          :treffpunkte,
+          :total_courses,
+
+          :beratung,
+
+          :mittelbeschaffung,
+          :verwaltung,
+          :total_remaining,
+
+          :total_paragraph_74,
+          :total_not_paragraph_74,
+
+          :total
+        ].freeze
+
+        self.model_class = ::TimeRecord
+
+        attr_reader :liste, :year
+
+        def initialize(liste)
+          super(liste.vereine)
+          @liste = liste
+          @year = 2022
+        end
+
+        def attribute_label(attr)
+          I18n.t(attr,
+            scope: fp_i18n_scope(model_class.name.tableize),
+            default: [human_attribute(attr)])
+        end
+
+        private
+
+        def attributes
+          [:group].tap do |attrs|
+            if liste.type == TimeRecord::VolunteerWithoutVerificationTime.sti_name
+              attrs.concat(ATTRS_LUFEB_SUM)
+            else
+              attrs.concat(ATTRS_LUFEB)
+            end
+            attrs.concat(ATTRS_GENERAL)
+          end
+        end
+
+        def row_for(verein, _format = nil)
+          Row.new(verein, liste.time_record(verein))
+        end
+
+        class Row
+          attr_reader :verein, :record
+
+          def initialize(verein, record)
+            @verein = verein
+            @record = record
+          end
+
+          def fetch(attr)
+            if attr == :group
+              verein.to_s
+            elsif record
+              record.send(attr)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/domain/fp2024/export/xlsx/cost_accounting/style.rb
+++ b/app/domain/fp2024/export/xlsx/cost_accounting/style.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2014-2021, Insieme Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::Export::Xlsx::CostAccounting
+  class Style < Export::Xlsx::Style
+    BLACK = "000000"
+    CURRENCY = 2
+
+    self.style_definition_labels += [:total_label, :total_currency,
+      :currency, :vereinsname,
+      :reporting_jahr, :default_border,
+      :centered_border,
+      :box, :box_top_left, :box_top, :box_top_right]
+
+    def column_widths
+      [57.62]
+    end
+
+    def header_styles
+      [nil, style_title_header_row, nil, style_combined_labels_row]
+    end
+
+    def row_styles
+      [].tap do |row|
+        row[4] = style_total_rows
+        row[7] = style_total_rows
+        row[8] = style_total_rows
+        row[9] = style_total_rows
+        row[15] = style_total_rows
+        row[17] = style_total_rows
+      end
+    end
+
+    def default_style_data_rows
+      [:default_border, :centered_border] +
+        Array.new(16, :currency)
+    end
+
+    def style_title_header_row
+      [:vereinsname, :reporting_jahr] +
+        Array.new(16, :centered)
+    end
+
+    def style_combined_labels_row
+      Array.new(4, :centered) + [:box_top_left, :box_top, :box_top_right] + Array.new(13, :centered)
+    end
+
+    private
+
+    def style_total_rows
+      [:total_label] +
+        Array.new(17, :total_currency)
+    end
+
+    # override default attribute labels style
+    def attribute_labels_style
+      default_border_style.deep_merge(
+        style: {
+          bg_color: LABEL_BACKGROUND,
+          alignment: {text_rotation: 90, vertical: :center, horizontal: :center}
+        },
+        height: 230
+      )
+    end
+
+    # override default style
+    def default_style
+      {
+        style: {
+          sz: 16,
+          font_name: Settings.xlsx.font_name,
+          alignment: {horizontal: :left}
+        }
+      }
+    end
+
+    def total_label_style
+      default_border_style.deep_merge(style: {bg_color: LABEL_BACKGROUND})
+    end
+
+    def total_currency_style
+      currency_style.deep_merge(style: {bg_color: LABEL_BACKGROUND})
+    end
+
+    def currency_style
+      centered_border_style.deep_merge(
+        style: {
+          num_fmt: CURRENCY,
+          alignment: {horizontal: :center}
+        }
+      )
+    end
+
+    def vereinsname_style
+      default_style.deep_merge(style: {sz: 20})
+    end
+
+    def reporting_jahr_style
+      centered_style.merge(style: {sz: 20, font_name: Settings.xlsx.font_name})
+    end
+
+    def box_top_left_style
+      box_style.deep_merge(style: {border: {edges: [:top, :left]}})
+    end
+
+    def box_top_style
+      box_style.deep_merge(style: {border: {edges: [:top]}})
+    end
+
+    def box_top_right_style
+      box_style.deep_merge(style: {border: {edges: [:top, :right]}})
+    end
+
+    def box_style
+      centered_border_style.deep_merge(style: {bg_color: LABEL_BACKGROUND})
+    end
+
+    def default_border_style
+      default_style.deep_merge(border_styling)
+    end
+
+    def centered_border_style
+      centered_style.deep_merge(border_styling)
+    end
+
+    def border_styling
+      {style: {border: {style: :thin, color: BLACK}}}
+    end
+
+    def centered_style
+      default_style.deep_merge(style: {alignment: {horizontal: :center}})
+    end
+  end
+end

--- a/app/domain/fp2024/export/xlsx/events/aggregate_course/style.rb
+++ b/app/domain/fp2024/export/xlsx/events/aggregate_course/style.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2020 Insieme Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::Export::Xlsx::Events::AggregateCourse
+  class Style < ::Export::Xlsx::Style
+    BLACK = "000000"
+    CURRENCY = 2
+    DATE = 14
+
+    self.data_row_height = 50
+
+    self.style_definition_labels += [:title, :default_border,
+      :centered_border, :vertical_centered,
+      :currency, :date,
+      :centered_border_small, :centered_border_wrap]
+
+    def column_widths
+      column_style_information.map(&:width)
+    end
+
+    def default_style_data_rows
+      column_style_information.map(&:style)
+    end
+
+    def header_styles
+      [nil, style_title_header_row, nil]
+    end
+
+    def row_styles
+      [].tap do |row|
+      end
+    end
+
+    ColumnStyleInformation = Struct.new(:width, :style)
+
+    def column_style_information # rubocop:disable Metrics/MethodLength
+      @column_style_information ||= [
+        [18, :centered_border_wrap],
+        [12.86, :centered_border_wrap],
+        [20, :centered_border_small],
+        [18, :centered_border_wrap],
+        [18, :centered_border_wrap],
+        [2.57, :vertical_centered],
+        [2.57, :vertical_centered],
+        [2.57, :vertical_centered],
+        [2.57, :vertical_centered],
+        [2.57, :vertical_centered],
+        [2.57, :vertical_centered],
+        [2.57, :vertical_centered],
+        [2.57, :vertical_centered],
+        [2.57, :vertical_centered],
+        [2.57, :vertical_centered],
+        [2.57, :vertical_centered],
+        [2.57, :vertical_centered],
+        [2.57, :vertical_centered],
+        [2.57, :vertical_centered],
+        [2.57, :vertical_centered],
+        [2.57, :vertical_centered],
+        [2.57, :vertical_centered],
+        [2.57, :vertical_centered],
+        [2.57, :vertical_centered],
+        [2.57, :vertical_centered],
+        [2.57, :currency],
+        [2.57, :currency],
+        [2.57, :currency],
+        [2.57, :currency],
+        [2.57, :currency],
+        [2.57, :currency],
+        [2.57, :currency],
+        [2.57, :vertical_centered],
+        [2.57, :vertical_centered],
+        [2.57, :currency],
+        [2.57, :currency]
+      ].map { |width, style| ColumnStyleInformation.new(width, style) }
+    end
+
+    def style_title_header_row
+      [:title] +
+        Array.new(3, :title) +
+        Array.new(12, :title) +
+        Array.new(31, :default) +
+        Array.new(33, :default)
+    end
+
+    private
+
+    # override default style
+    def default_style
+      {style: {
+        font_name: Settings.xlsx.font_name, sz: 10, alignment: {horizontal: :left}
+      }}
+    end
+
+    # override default attribute labels style
+    def attribute_labels_style
+      default_border_style.deep_merge(
+        style: {
+          bg_color: LABEL_BACKGROUND,
+          alignment: {text_rotation: 90, vertical: :center, horizontal: :center}
+        },
+        height: 285
+      )
+    end
+
+    def vertical_centered_style
+      default_border_style.deep_merge(
+        style: {
+          alignment: {text_rotation: 90, vertical: :center, horizontal: :center}
+        }
+      )
+    end
+
+    def default_border_style
+      default_style.deep_merge(border_styling)
+    end
+
+    def centered_border_style
+      centered_style.deep_merge(border_styling).deep_merge(
+        style: {
+          alignment: {vertical: :center, horizontal: :center}
+        }
+      )
+    end
+
+    def centered_border_wrap_style
+      centered_border_style.deep_merge(style: {alignment: {wrap_text: true}})
+    end
+
+    def centered_border_small_style
+      centered_border_style.deep_merge(style: {sz: 8, alignment: {wrap_text: true}})
+    end
+
+    def currency_style
+      vertical_centered_style.deep_merge(
+        style: {num_fmt: CURRENCY}
+      )
+    end
+
+    def date_style
+      centered_border_style.deep_merge(
+        style: {num_fmt: DATE}
+      )
+    end
+
+    def border_styling
+      {style: {border: {style: :thin, color: BLACK}}}
+    end
+
+    def title_style
+      default_style.deep_merge(style: {sz: 16})
+    end
+  end
+end

--- a/app/domain/fp2024/statistics/group_figures.rb
+++ b/app/domain/fp2024/statistics/group_figures.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2015-2021, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024::Statistics
+  class GroupFigures
+    include Featureperioden::Domain
+
+    attr_reader :year
+
+    def initialize(year)
+      @year = year
+    end
+
+    def groups
+      @groups ||= Group.where(type: [Group::Dachverein,
+        Group::Regionalverein,
+        Group::ExterneOrganisation].collect(&:sti_name)).order_by_type
+    end
+
+    def leistungskategorien
+      Event::Reportable::LEISTUNGSKATEGORIEN
+    end
+
+    def fachkonzepte
+      Event::Reportable::FACHKONZEPTE
+    end
+
+    def course_record(group, leistungskategorie, fachkonzept)
+      course_records[group.id][leistungskategorie][fachkonzept]
+    end
+
+    def employee_time(group)
+      time_records[group.id][TimeRecord::EmployeeTime.sti_name]
+    end
+
+    def volunteer_with_verification_time(group)
+      time_records[group.id][TimeRecord::VolunteerWithVerificationTime.sti_name]
+    end
+
+    def volunteer_without_verification_time(group)
+      time_records[group.id][TimeRecord::VolunteerWithoutVerificationTime.sti_name]
+    end
+
+    def employee_pensum(group)
+      employee_pensums[group.id]
+    end
+
+    def cost_accounting_table(group)
+      cost_accounting.table(group)
+    end
+
+    def capital_substrate(group)
+      fp_class("TimeRecord::Report::CapitalSubstrate").new(capital_substrate_time_table(group))
+    end
+
+    def capital_substrate_factor(group)
+      fp_class("TimeRecord::Report::CapitalSubstrateFactor").new(
+        capital_substrate_time_table(group)
+      )
+    end
+
+    private
+
+    def course_records
+      @course_records ||= begin
+        hash = Hash.new { |h1, k1| h1[k1] = Hash.new { |h2, k2| h2[k2] = {} } }
+        load_course_records.each do |record|
+          hash[record.group_id][record.leistungskategorie][record.fachkonzept] = record
+        end
+        hash
+      end
+    end
+
+    def load_course_records
+      Event::CourseRecord.select(course_record_columns)
+        .joins(:event)
+        .joins("INNER JOIN events_groups ON events.id = events_groups.event_id")
+        .where(year: year, subventioniert: true)
+        .group("events_groups.group_id, events.leistungskategorie, " \
+                                "events.fachkonzept")
+    end
+
+    def course_record_columns
+      "events_groups.group_id, events.leistungskategorie, " \
+      "events.fachkonzept, " \
+      "MAX(event_course_records.year) AS year, " \
+      "SUM(anzahl_kurse) AS anzahl_kurse, " \
+      "SUM(tage_behinderte) AS tage_behinderte, " \
+      "SUM(tage_angehoerige) AS tage_angehoerige, " \
+      "SUM(tage_weitere) AS tage_weitere, " \
+      "SUM(direkter_aufwand) AS direkter_aufwand, " \
+      "SUM(betreuungsstunden) AS betreuungsstunden, " \
+      "SUM(gemeinkostenanteil) AS gemeinkostenanteil"
+    end
+
+    def time_records
+      @time_records ||= begin
+        hash = Hash.new { |h, k| h[k] = {} }
+        TimeRecord.where(year: year).find_each do |record|
+          hash[record.group_id][record.type] = record
+        end
+        hash
+      end
+    end
+
+    def employee_pensums
+      @employee_pensums ||= TimeRecord::EmployeePensum
+        .select("*, time_records.group_id AS group_id")
+        .joins(:time_record)
+        .where(time_records: {year: year})
+        .index_by(&:group_id)
+    end
+
+    # Fp2024::CostAccounting::Aggregation
+    def cost_accounting
+      @cost_accounting ||= fp_class("CostAccounting::Aggregation").new(year)
+    end
+
+    def capital_substrate_time_table(group)
+      cost_table = cost_accounting_table(group) || nil_cost_accounting_table(group)
+      substrate = capital_substrates[group.id]
+      fp_class("TimeRecord::Table").new(group, year, cost_table).tap do |t|
+        t.records = {fp_class("TimeRecord::Report::CapitalSubstrate").key => substrate}
+      end
+    end
+
+    def nil_cost_accounting_table(group)
+      fp_class("CostAccounting::Table").new(group, year).tap do |table|
+        table.set_records(nil, nil, nil)
+      end
+    end
+
+    def capital_substrates
+      @capital_substrates ||= begin
+        cs_hash = CapitalSubstrate.where(year: year).index_by(&:group_id)
+        cs_hash.default_proc = proc do |_hash, key|
+          CapitalSubstrate.new(group_id: key, year: year)
+        end
+        cs_hash
+      end
+    end
+  end
+end

--- a/app/domain/fp2024/time_record/calculation.rb
+++ b/app/domain/fp2024/time_record/calculation.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2021, Insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024
+  class TimeRecord::Calculation
+    DEFAULT_BSV_HOURS_PER_YEAR = 1900
+    ASSUMED_HOURLY_RATE = 130
+
+    attr_reader :record
+
+    def initialize(record)
+      @record = record
+    end
+
+    delegate :total_lufeb_general,
+      :total_lufeb_private,
+      :total_lufeb_specific,
+      :total_lufeb_promoting,
+      :nicht_art_74_leistungen,
+      :verwaltung,
+      :beratung,
+      :treffpunkte,
+      :blockkurse,
+      :tageskurse,
+      :jahreskurse,
+      :kontakte_medien,
+      :interviews,
+      :publikationen,
+      :referate,
+      :medienkonferenzen,
+      :informationsveranstaltungen,
+      :sensibilisierungskampagnen,
+      :auskunftserteilung,
+      :kontakte_meinungsbildner,
+      :beratung_medien,
+      :eigene_zeitschriften,
+      :newsletter,
+      :informationsbroschueren,
+      :eigene_webseite,
+      :erarbeitung_instrumente,
+      :erarbeitung_grundlagen,
+      :projekte,
+      :vernehmlassungen,
+      :gremien,
+      :vermittlung_kontakte,
+      :unterstuetzung_selbsthilfeorganisationen,
+      :koordination_selbsthilfe,
+      :treffen_meinungsaustausch,
+      :beratung_fachhilfeorganisationen,
+      :unterstuetzung_behindertenhilfe,
+      :mittelbeschaffung,
+      :allgemeine_auskunftserteilung,
+      :type,
+      :year,
+      :unterstuetzung_leitorgane,
+      :freiwilligen_akquisition,
+      :auskuenfte,
+      :medien_zusammenarbeit,
+      :medien_grundlagen,
+      :website,
+      :videos,
+      :social_media,
+      :beratungsmodule,
+      :apps,
+      :total_media,
+      :kurse_grundlagen,
+      :treffpunkte_grundlagen,
+      :lufeb_grundlagen,
+      to: :record
+
+    def total_lufeb
+      total_lufeb_grundlagen.to_i +
+        total_lufeb_promoting.to_i +
+        total_lufeb_general.to_i +
+        total_lufeb_specific.to_i
+    end
+
+    def total_lufeb_grundlagen
+      lufeb_grundlagen.to_i
+    end
+
+    def total_courses
+      kurse_grundlagen.to_i +
+        blockkurse.to_i +
+        tageskurse.to_i +
+        jahreskurse.to_i +
+        treffpunkte_grundlagen.to_i +
+        treffpunkte.to_i
+    end
+
+    def total_additional_person_specific
+      beratung.to_i
+    end
+
+    def total_remaining
+      mittelbeschaffung.to_i +
+        verwaltung.to_i
+    end
+
+    def total_paragraph_74
+      @total_paragraph_74 ||=
+        total_lufeb.to_i +
+        total_media.to_i +
+        total_courses.to_i +
+        total_additional_person_specific.to_i +
+        total_remaining.to_i
+    end
+
+    def total_not_paragraph_74
+      nicht_art_74_leistungen.to_i
+    end
+
+    def total
+      total_paragraph_74.to_i +
+        total_not_paragraph_74.to_i
+    end
+
+    def total_paragraph_74_pensum
+      total_paragraph_74.to_d / bsv_hours_per_year
+    end
+
+    def total_not_paragraph_74_pensum
+      total_not_paragraph_74.to_d / bsv_hours_per_year
+    end
+
+    def total_pensum
+      total.to_d / bsv_hours_per_year
+    end
+
+    def update_totals
+      @total_paragraph_74 = nil # rubocop:disable Naming/VariableNumber
+      calculate_total_lufeb_promoting
+      calculate_total_lufeb_general
+      calculate_total_lufeb_specific
+      calculate_total_media
+    end
+
+    private
+
+    def bsv_hours_per_year
+      globals ? globals.bsv_hours_per_year : DEFAULT_BSV_HOURS_PER_YEAR
+    end
+
+    def globals
+      @globals ||= ReportingParameter.for(year)
+    end
+
+    def calculate_total_lufeb_promoting
+      @record.total_lufeb_promoting =
+        beratung_fachhilfeorganisationen.to_i +
+        unterstuetzung_leitorgane.to_i +
+        freiwilligen_akquisition.to_i
+    end
+
+    def calculate_total_lufeb_general
+      @record.total_lufeb_general =
+        auskuenfte.to_i +
+        referate.to_i +
+        medien_zusammenarbeit.to_i +
+        sensibilisierungskampagnen.to_i
+    end
+
+    def calculate_total_lufeb_specific
+      @record.total_lufeb_specific =
+        erarbeitung_grundlagen.to_i +
+        gremien.to_i +
+        vernehmlassungen.to_i +
+        projekte.to_i
+    end
+
+    def calculate_total_media
+      @record.total_media = [
+        :medien_grundlagen,
+        :website,
+        :newsletter,
+        :videos,
+        :social_media,
+        :beratungsmodule,
+        :apps
+      ].map { |attr| send(attr).to_i }.sum
+    end
+  end
+end

--- a/app/domain/fp2024/time_record/lufeb_pro_verein.rb
+++ b/app/domain/fp2024/time_record/lufeb_pro_verein.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2021, Insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024
+  class TimeRecord::LufebProVerein
+    attr_reader :year
+
+    def initialize(year)
+      @year = year
+      @lufeb_data = {}
+    end
+
+    def vereine
+      @vereine ||= Group.by_bsv_number.all
+    end
+
+    Data = Struct.new(:general, :specific, :promoting, :lufeb_grundlagen, :kurse_grundlagen)
+
+    def lufeb_data_for(verein_id)
+      @lufeb_data[verein_id] ||= Data.new(*time_records[verein_id])
+    end
+
+    private
+
+    def time_records # rubocop:disable Metrics/MethodLength
+      @time_records ||=
+        ::TimeRecord
+          .where(year: @year, type: [
+            "TimeRecord::EmployeeTime",
+            "TimeRecord::VolunteerWithVerificationTime"
+          ])
+          .group(:group_id)
+          .select([
+            "group_id",
+            "SUM(total_lufeb_general) AS general",
+            "SUM(total_lufeb_specific) AS specific",
+            "SUM(total_lufeb_promoting) AS promoting",
+            "SUM(lufeb_grundlagen) AS lufeb_grundlagen",
+            "SUM(kurse_grundlagen) AS kurse_grundlagen"
+          ].join(", "))
+          .all
+          .each_with_object({}) do |tr, memo|
+          memo[tr.group_id] = [
+            tr.general,
+            tr.specific,
+            tr.promoting,
+            tr.lufeb_grundlagen,
+            tr.kurse_grundlagen
+          ]
+        end
+    end
+  end
+end

--- a/app/domain/fp2024/time_record/organisations_daten.rb
+++ b/app/domain/fp2024/time_record/organisations_daten.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2021-2023, Insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024
+  class TimeRecord::OrganisationsDaten
+    include Featureperioden::Domain
+
+    attr_reader :year
+
+    def initialize(year)
+      @year = year
+      @data_for = {}
+    end
+
+    def vereine
+      @vereine ||= Group.by_bsv_number.all
+    end
+
+    def data_for(verein)
+      raise ArgumentError unless verein.is_a?(Group)
+
+      @data_for[verein.id] ||= Data.new(*fetch_organsations_daten(verein, year))
+    end
+
+    Data = Struct.new(
+      :employee_time_total,
+      :employee_time_art_74,
+      :volunteer_verified_time_total,
+      :volunteer_unverified_time_total,
+      :volunteer_time_art_74
+    ) do
+      def angestellte_insgesamt
+        employee_time_total
+      end
+
+      def angestellte_art_74
+        employee_time_art_74
+      end
+
+      def freiwillige_insgesamt
+        volunteer_verified_time_total + volunteer_unverified_time_total
+      end
+
+      def freiwillige_art_74
+        volunteer_time_art_74
+      end
+    end
+
+    private
+
+    def fetch_organsations_daten(verein, year)
+      table = fp_class("TimeRecord::Table").new(verein, year)
+
+      [
+        table.value_of("employee_pensum", :total).to_d,
+        table.value_of("employee_pensum", :paragraph_74).to_d,
+        table.record("volunteer_with_verification_time").total_pensum.to_d,
+        table.record("volunteer_without_verification_time").total_pensum.to_d,
+        table.record("volunteer_with_verification_time").total_paragraph_74_pensum.to_d
+      ]
+    end
+  end
+end

--- a/app/domain/fp2024/time_record/report/base.rb
+++ b/app/domain/fp2024/time_record/report/base.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2014, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024
+  class TimeRecord::Report::Base
+    FIELDS = %w[paragraph_74 not_paragraph_74 total].freeze
+
+    class << self
+      def key
+        name.demodulize.underscore
+      end
+
+      def human_name
+        I18n.t("time_records.report.#{key}.name")
+      end
+    end
+
+    attr_reader :table
+
+    # The kind of the report, e.g. controlling, capital_substrate
+    class_attribute :kind
+
+    delegate :key, :human_name, to: :class
+
+    def initialize(table)
+      @table = table
+    end
+
+    # define accessor methods for all fields, returning nil
+    FIELDS.each do |f|
+      define_method(f) {}
+    end
+
+    private
+
+    def record
+      @record ||= table.record(key)
+    end
+  end
+end

--- a/app/domain/fp2024/time_record/report/capital_substrate.rb
+++ b/app/domain/fp2024/time_record/report/capital_substrate.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2020-2022, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024
+  class TimeRecord::Report::CapitalSubstrate < TimeRecord::Report::Base
+    include Featureperioden::Domain
+
+    delegate :year, to: :table
+
+    self.kind = :capital_substrate
+
+    DECKUNGSBEITRAG4_THRESHOLD = 300_000.0
+
+    def initialize(*args)
+      super
+      @time_record_tables = {}
+    end
+
+    def allocation_base
+      if table.cost_accounting_value_of("total_aufwand", "aufwand_ertrag_fibu").nonzero?
+        table.cost_accounting_value_of("vollkosten", "total").to_d /
+          table.cost_accounting_value_of("total_aufwand", "aufwand_ertrag_fibu").to_d
+      else
+        0
+      end
+    end
+
+    def organization_capital_allocated
+      allocation_base.to_d * record.organization_capital.to_d
+    end
+
+    def deckungsbeitrag4_fp2015
+      record.newest_previous_sum.to_d
+    end
+
+    def deckungsbeitrag4_fp2020
+      deckungsbeitrag4_period(2020, table.year)
+    end
+
+    def deckungsbeitrag4_sum
+      deckungsbeitrag4_fp2015 + deckungsbeitrag4_fp2020
+    end
+
+    def deckungsbeitrag4
+      deckungsbeitrag4_total = table.cost_accounting_value_of("beitraege_iv", "total").to_d
+      return 0 if deckungsbeitrag4_total >= DECKUNGSBEITRAG4_THRESHOLD
+
+      deckungsbeitrag4_sum
+    end
+
+    def iv_finanzierungsgrad_since_2015
+      iv_finanzierungsgrad_period(2015, table.year).to_d
+    end
+
+    def iv_finanzierungsgrad_fp2015
+      iv_finanzierungsgrad_period(2015, 2019).to_d
+    end
+
+    def iv_finanzierungsgrad_fp2020
+      iv_finanzierungsgrad_period(2020, current_or(2020, 2023)).to_d
+    end
+
+    def iv_finanzierungsgrad_current
+      iv_finanzierungsgrad_period(table.year, table.year).to_d
+    end
+
+    def exemption
+      globals ? - globals.capital_substrate_exemption.to_d : 0
+    end
+
+    def capital_substrate_allocated
+      organization_capital_allocated.to_d +
+        record.earmarked_funds.to_d +
+        deckungsbeitrag4.to_d +
+        exemption.to_d
+    end
+
+    def paragraph_74
+      capital_substrate_allocated
+    end
+
+    def current_or(lower, upper)
+      current = table.year
+
+      return current if (lower..upper).cover?(current)
+
+      return lower if current < lower
+      upper if current > upper
+    end
+
+    private
+
+    def deckungsbeitrag4_period(start, finish)
+      (start..finish).sum do |y|
+        time_record_table(y).cost_accounting_value_of("deckungsbeitrag4", "total").to_d
+      end
+    end
+
+    def iv_finanzierungsgrad_period(start, finish)
+      summe_finanzierungsgrade = (start..finish).sum do |y|
+        total_iv_beitrag = time_record_table(y).cost_accounting_value_of("beitraege_iv", "aufwand_ertrag_fibu").to_d # rubocop:disable Layout/LineLength
+        gesamtkosten = time_record_table(y).cost_accounting_value_of("total_aufwand", "aufwand_ertrag_ko_re").to_d # rubocop:disable Layout/LineLength
+
+        next BigDecimal(0) if gesamtkosten.zero?
+
+        total_iv_beitrag / gesamtkosten
+      end
+
+      anzahl_jahre = (start..finish).to_a.size.to_d
+
+      summe_finanzierungsgrade / anzahl_jahre
+    end
+
+    def time_record_table(year)
+      @time_record_tables[year] ||= fp_class("TimeRecord::Table").new(table.group, year)
+    end
+
+    def globals
+      @globals ||= ReportingParameter.for(table.year)
+    end
+  end
+end

--- a/app/domain/fp2024/time_record/report/capital_substrate.rb
+++ b/app/domain/fp2024/time_record/report/capital_substrate.rb
@@ -33,16 +33,25 @@ module Fp2024
       allocation_base.to_d * record.organization_capital.to_d
     end
 
+    # display DB4 values per BSV contractperiod
     def deckungsbeitrag4_fp2015
-      record.newest_previous_sum.to_d
+      deckungsbeitrag4_period(2015, 2019)
     end
 
     def deckungsbeitrag4_fp2020
-      deckungsbeitrag4_period(2020, table.year)
+      deckungsbeitrag4_period(2020, 2023)
     end
 
+    def deckungsbeitrag4_fp2024
+      deckungsbeitrag4_period(2024, [2027, table.year].min)
+    end
+
+    # total DB4 up to current year
+    # newest_previous_sum is defined in App::Models::CapitalSubstrate;
+    # the method returns previous_substrate_sum, which is derived from an extern csv
+    # and written into the database via lib/tasks/db.rake
     def deckungsbeitrag4_sum
-      deckungsbeitrag4_fp2015 + deckungsbeitrag4_fp2020
+      record.newest_previous_sum.to_d + deckungsbeitrag4_fp2024
     end
 
     def deckungsbeitrag4

--- a/app/domain/fp2024/time_record/report/capital_substrate.rb
+++ b/app/domain/fp2024/time_record/report/capital_substrate.rb
@@ -70,7 +70,11 @@ module Fp2024
     end
 
     def iv_finanzierungsgrad_fp2020
-      iv_finanzierungsgrad_period(2020, current_or(2020, 2023)).to_d
+      iv_finanzierungsgrad_period(2020, 2023).to_d
+    end
+
+    def iv_finanzierungsgrad_fp2024
+      iv_finanzierungsgrad_period(2024, [2027, table.year].min).to_d
     end
 
     def iv_finanzierungsgrad_current

--- a/app/domain/fp2024/time_record/report/capital_substrate_factor.rb
+++ b/app/domain/fp2024/time_record/report/capital_substrate_factor.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2020, Insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024
+  class TimeRecord::Report::CapitalSubstrateFactor < TimeRecord::Report::Base
+    self.kind = :capital_substrate
+
+    def paragraph_74
+      return 0 if vollkosten_total.zero?
+
+      capital_substrate / vollkosten_total
+    end
+
+    private
+
+    def capital_substrate
+      table.value_of("capital_substrate", "paragraph_74")
+    end
+
+    def vollkosten_total
+      table.cost_accounting_value_of("vollkosten", "total")
+    end
+  end
+end

--- a/app/domain/fp2024/time_record/report/capital_substrate_limit.rb
+++ b/app/domain/fp2024/time_record/report/capital_substrate_limit.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2020, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024
+  class TimeRecord::Report::CapitalSubstrateLimit < TimeRecord::Report::Base
+    self.kind = :capital_substrate
+
+    def paragraph_74
+      limit.to_d * table.cost_accounting_value_of("vollkosten", "total")
+    end
+
+    private
+
+    def limit
+      @limit ||= ReportingParameter.for(table.year).capital_substrate_limit
+    end
+  end
+end

--- a/app/domain/fp2024/time_record/report/employee_efforts.rb
+++ b/app/domain/fp2024/time_record/report/employee_efforts.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2014, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024
+  class TimeRecord::Report::EmployeeEfforts < TimeRecord::Report::Base
+    self.kind = :controlling
+
+    def paragraph_74
+      table.cost_accounting_value_of("total_personalaufwand", "aufwand_ertrag_ko_re") -
+        table.cost_accounting_value_of("honorare", "aufwand_ertrag_ko_re")
+    end
+  end
+end

--- a/app/domain/fp2024/time_record/report/employee_efforts_pensum.rb
+++ b/app/domain/fp2024/time_record/report/employee_efforts_pensum.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2014, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024
+  class TimeRecord::Report::EmployeeEffortsPensum < TimeRecord::Report::Base
+    self.kind = :controlling
+
+    def paragraph_74
+      if table.value_of("employee_time", "paragraph_74").nonzero?
+        table.value_of("employee_efforts", "paragraph_74").to_d /
+          table.value_of("employee_time", "paragraph_74").to_d
+      else
+        0
+      end
+    end
+  end
+end

--- a/app/domain/fp2024/time_record/report/employee_pensum.rb
+++ b/app/domain/fp2024/time_record/report/employee_pensum.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2014, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024
+  class TimeRecord::Report::EmployeePensum < TimeRecord::Report::Base
+    delegate :paragraph_74, to: :record
+
+    delegate :not_paragraph_74, to: :record
+
+    delegate :total, to: :record
+
+    private
+
+    def record
+      table.record("employee_time").employee_pensum ||
+        table.record("employee_time").build_employee_pensum
+    end
+  end
+end

--- a/app/domain/fp2024/time_record/report/employee_time.rb
+++ b/app/domain/fp2024/time_record/report/employee_time.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2023, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024
+  class TimeRecord::Report::EmployeeTime < TimeRecord::Report::Base
+    def paragraph_74
+      record.total_paragraph_74_pensum
+    end
+
+    def not_paragraph_74
+      record.total_not_paragraph_74_pensum
+    end
+
+    def total
+      record.total_pensum
+    end
+  end
+end

--- a/app/domain/fp2024/time_record/report/volunteer_with_verification_time.rb
+++ b/app/domain/fp2024/time_record/report/volunteer_with_verification_time.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2014, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024
+  class TimeRecord::Report::VolunteerWithVerificationTime < TimeRecord::Report::Base
+    def paragraph_74
+      record.total_paragraph_74_pensum
+    end
+
+    def not_paragraph_74
+      record.total_not_paragraph_74_pensum
+    end
+
+    def total
+      record.total_pensum
+    end
+  end
+end

--- a/app/domain/fp2024/time_record/report/volunteer_without_verification_time.rb
+++ b/app/domain/fp2024/time_record/report/volunteer_without_verification_time.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2014, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024
+  class TimeRecord::Report::VolunteerWithoutVerificationTime < TimeRecord::Report::Base
+    def paragraph_74
+      record.total_paragraph_74_pensum
+    end
+
+    def not_paragraph_74
+      record.total_not_paragraph_74_pensum
+    end
+
+    def total
+      record.total_pensum
+    end
+  end
+end

--- a/app/domain/fp2024/time_record/table.rb
+++ b/app/domain/fp2024/time_record/table.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2020, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024
+  class TimeRecord::Table
+    REPORTS = [Fp2024::TimeRecord::Report::EmployeePensum,
+      Fp2024::TimeRecord::Report::EmployeeTime,
+      Fp2024::TimeRecord::Report::VolunteerWithoutVerificationTime,
+      Fp2024::TimeRecord::Report::VolunteerWithVerificationTime,
+      Fp2024::TimeRecord::Report::EmployeeEfforts,
+      Fp2024::TimeRecord::Report::EmployeeEffortsPensum,
+      Fp2024::TimeRecord::Report::CapitalSubstrate,
+      Fp2024::TimeRecord::Report::CapitalSubstrateLimit,
+      Fp2024::TimeRecord::Report::CapitalSubstrateFactor].freeze
+
+    attr_reader :group, :year
+
+    attr_writer :records
+
+    class << self
+      def fields
+        CostAccounting::Report::Base::FIELDS
+      end
+    end
+
+    def initialize(group, year, cost_accounting_table = nil)
+      @group = group
+      @year = year
+      @cost_accounting_table = cost_accounting_table || CostAccounting::Table.new(group, year)
+    end
+
+    def reports
+      @reports ||= REPORTS.each_with_object({}) do |report, hash|
+        hash[report.key] = report.new(self)
+      end
+    end
+
+    def value_of(report, field)
+      reports.fetch(report).send(field)
+    end
+
+    def cost_accounting_value_of(report, field)
+      @cost_accounting_table.value_of(report, field)
+    end
+
+    def record(report_key)
+      model = record_model(report_key)
+      if model
+        records[report_key] ||=
+          model.where(group_id: group.id, year: year).first_or_initialize
+      end
+    end
+
+    private
+
+    def records
+      @records ||= {}
+    end
+
+    def record_model(report_key)
+      report_key.camelize.constantize
+    rescue NameError
+      begin
+        "TimeRecord::#{report_key.camelize}".constantize
+      rescue NameError
+        nil
+      end
+    end
+  end
+end

--- a/app/domain/fp2024/time_record/vereinsliste.rb
+++ b/app/domain/fp2024/time_record/vereinsliste.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2020, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+module Fp2024
+  class TimeRecord::Vereinsliste
+    attr_reader :year, :type
+
+    # type is one of
+    # - TimeRecord::EmployeeTime
+    # - TimeRecord::VolunteerWithVerificationTime
+    # - TimeRecord::VolunteerWithoutVerificationTime
+    def initialize(year, type)
+      @year = year
+      @type = type
+    end
+
+    def vereine
+      @vereine ||=
+        Group
+          .without_deleted
+          .where(type: [
+            Group::Dachverein,
+            Group::Regionalverein,
+            Group::ExterneOrganisation
+          ].collect(&:sti_name))
+          .order_by_type
+    end
+
+    def time_record(verein)
+      time_records[verein.id]
+    end
+
+    def time_records
+      @time_records ||= ::TimeRecord.where(type: type, year: year).index_by(&:group_id)
+    end
+  end
+end

--- a/app/views/fp2024/capital_substrate/edit.html.haml
+++ b/app/views/fp2024/capital_substrate/edit.html.haml
@@ -21,8 +21,8 @@
     = f.labeled_input_field :earmarked_funds, addon: t('global.currency'), help_inline: t('.help_per_date', date: f(Date.new(year).end_of_year))
 
   = field_set_tag do
-    = f.labeled_readonly_value :deckungsbeitrag4_fp2015, value: format_money(report.deckungsbeitrag4_fp2015)
     = f.labeled_readonly_value :deckungsbeitrag4_fp2020, value: format_money(report.deckungsbeitrag4_fp2020)
+    = f.labeled_readonly_value :deckungsbeitrag4_fp2024, value: format_money(report.deckungsbeitrag4_fp2024)
     = f.labeled_readonly_value :deckungsbeitrag4_sum, label: t('.deckungsbeitrag4_sum', year: report.year), value: format_money(report.deckungsbeitrag4_sum)
     %p= t('.deckungsbeitrag4_sum_notice').html_safe
 

--- a/app/views/fp2024/capital_substrate/edit.html.haml
+++ b/app/views/fp2024/capital_substrate/edit.html.haml
@@ -32,6 +32,6 @@
 
   = field_set_tag do
     = f.labeled_readonly_value :iv_finanzierungsgrad_since_2015, value: format_percent(report.iv_finanzierungsgrad_since_2015 * 100), label: t('.iv_finanzierungsgrad_since_2015', year: report.year)
-    = f.labeled_readonly_value :iv_finanzierungsgrad_fp2015,     value: format_percent(report.iv_finanzierungsgrad_fp2015 * 100), label: t('.iv_finanzierungsgrad_fp2015')
     = f.labeled_readonly_value :iv_finanzierungsgrad_fp2020,     value: format_percent(report.iv_finanzierungsgrad_fp2020 * 100), label: t('.iv_finanzierungsgrad_fp2020')
+    = f.labeled_readonly_value :iv_finanzierungsgrad_fp2024,     value: format_percent(report.iv_finanzierungsgrad_fp2024 * 100), label: t('.iv_finanzierungsgrad_fp2024')
     = f.labeled_readonly_value :iv_finanzierungsgrad_current,    value: format_percent(report.iv_finanzierungsgrad_current * 100), label: t('.iv_finanzierungsgrad_current', year: report.year)

--- a/app/views/fp2024/capital_substrate/edit.html.haml
+++ b/app/views/fp2024/capital_substrate/edit.html.haml
@@ -1,0 +1,37 @@
+-#  Copyright (c) 2012-2014, insieme Schweiz. This file is part of
+-#  hitobito_insieme and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito_insieme.
+
+- @subtitle = I18n.t('crud.edit.title', model: entry)
+
+= reporting_frozen_message
+
+= crud_form(entry,
+            url: capital_substrate_group_path(group, year),
+            cancel_url: capital_substrate_group_path(group, year: year),
+            buttons_top: !reporting_frozen?,
+            buttons_bottom: !reporting_frozen?,
+            method: :put,
+            html: { class: 'long-labeled report', data: { readonly: reporting_frozen? } }) do |f|
+
+  = field_set_tag do
+    = f.labeled_readonly_value :allocation_base, value: fnumber(report.allocation_base)
+    = f.labeled_input_field :organization_capital, addon: t('global.currency'), help_inline: t('.help_per_date', date: f(Date.new(year).end_of_year))
+    = f.labeled_input_field :earmarked_funds, addon: t('global.currency'), help_inline: t('.help_per_date', date: f(Date.new(year).end_of_year))
+
+  = field_set_tag do
+    = f.labeled_readonly_value :deckungsbeitrag4_fp2015, value: format_money(report.deckungsbeitrag4_fp2015)
+    = f.labeled_readonly_value :deckungsbeitrag4_fp2020, value: format_money(report.deckungsbeitrag4_fp2020)
+    = f.labeled_readonly_value :deckungsbeitrag4_sum, label: t('.deckungsbeitrag4_sum', year: report.year), value: format_money(report.deckungsbeitrag4_sum)
+    %p= t('.deckungsbeitrag4_sum_notice').html_safe
+
+  = field_set_tag do
+    = f.labeled_readonly_value :exemption, value: format_money(report.exemption)
+    = f.labeled_readonly_value :capital_substrate_allocated, value: format_money(report.capital_substrate_allocated)
+
+  = field_set_tag do
+    = f.labeled_readonly_value :iv_finanzierungsgrad_since_2015, value: format_percent(report.iv_finanzierungsgrad_since_2015 * 100), label: t('.iv_finanzierungsgrad_since_2015', year: report.year)
+    = f.labeled_readonly_value :iv_finanzierungsgrad_fp2015,     value: format_percent(report.iv_finanzierungsgrad_fp2015 * 100), label: t('.iv_finanzierungsgrad_fp2015')
+    = f.labeled_readonly_value :iv_finanzierungsgrad_fp2020,     value: format_percent(report.iv_finanzierungsgrad_fp2020 * 100), label: t('.iv_finanzierungsgrad_fp2020')
+    = f.labeled_readonly_value :iv_finanzierungsgrad_current,    value: format_percent(report.iv_finanzierungsgrad_current * 100), label: t('.iv_finanzierungsgrad_current', year: report.year)

--- a/app/views/fp2024/controlling/index.html.haml
+++ b/app/views/fp2024/controlling/index.html.haml
@@ -1,0 +1,63 @@
+-#  Copyright (c) 2020, insieme Schweiz. This file is part of
+-#  hitobito_insieme and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito_insieme.
+
+.row
+  .col-12= render 'shared/page_per_year'
+
+.row
+
+
+%h3= t('.controlling')
+
+= action_button(t('.cost_accounting'),
+                cost_accounting_controlling_group_path(year: year, format: :xlsx),
+                :download)
+
+= action_button(t('.pro_verein'),
+                pro_verein_controlling_group_path(year: year, format: :csv),
+                :download)
+
+= action_button(t('.client_statistics'),
+                client_statistics_controlling_group_path(year: year, format: :csv),
+                :download)
+
+= action_button(t('.group_figures'),
+                group_figures_controlling_group_path(year: year, format: :csv),
+                :download)
+
+= action_button(t('.group_data'),
+                group_data_controlling_group_path(year: year, format: :csv),
+                :download)
+
+%h3= t('.export_time_records')
+
+- [TimeRecord::EmployeeTime,
+   TimeRecord::VolunteerWithVerificationTime,
+   TimeRecord::VolunteerWithoutVerificationTime].each do |klass|
+  = action_button(t(".time_records.#{klass.name.demodulize.underscore}"),
+                  time_records_controlling_group_path(year: year, type: klass.sti_name, format: :csv),
+                  :download)
+
+= action_button(t(".lufeb_times"),
+                lufeb_times_controlling_group_path(year: year, format: :csv),
+                :download)
+
+- params[:year] ||= @year
+
+%h3= t('.export_bk')
+= course_aggregation_csv_button(lk: :bk, consolidate: true, year: @year)
+= course_aggregation_csv_button(lk: :bk, subsidized: false, consolidate: true, year: @year)
+
+%h3= t('.export_tk')
+= course_aggregation_csv_button(lk: :tk, consolidate: true, year: @year)
+= course_aggregation_csv_button(lk: :tk, subsidized: false, consolidate: true, year: @year)
+
+%h3= t('.export_sk')
+= course_aggregation_csv_button(lk: :sk, consolidate: true, year: @year)
+= course_aggregation_csv_button(lk: :sk, subsidized: false, consolidate: true, year: @year)
+
+%h3= t('.export_tp')
+= course_aggregation_csv_button(lk: :tp, consolidate: true, year: @year)
+= course_aggregation_csv_button(lk: :tp, subsidized: false, consolidate: true, year: @year)

--- a/app/views/fp2024/cost_accounting/edit.html.haml
+++ b/app/views/fp2024/cost_accounting/edit.html.haml
@@ -1,0 +1,58 @@
+-#  Copyright (c) 2012-2020, insieme Schweiz. This file is part of
+-#  hitobito_insieme and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito_insieme.
+
+- @subtitle = I18n.t('crud.edit.title', model: entry)
+
+= reporting_frozen_message
+
+= crud_form(entry, url: cost_accounting_report_group_path(group, year, entry.report),
+                   cancel_url: cost_accounting_group_path(group, year: year),
+                   buttons_top: !reporting_frozen?,
+                   buttons_bottom: !reporting_frozen?,
+                   method: :put,
+                   html: { class: 'report', data: { readonly: reporting_frozen? } }) do |f|
+
+  - if report.editable_fields.include?('aufwand_ertrag_fibu')
+    = f.labeled_input_field(:aufwand_ertrag_fibu,
+                            label: report.aufwand ? t('.aufwand_fibu') : t('.ertrag_fibu'),
+                            addon: t('global.currency'))
+
+  - if report.editable_fields.include?('aufteilung_kontengruppen')
+    = f.labeled_input_field(:aufteilung_kontengruppen)
+    - if previous_entry.aufteilung_kontengruppen.present?
+      #cost_accounting_note_copy.hidden
+        = f.labeled(:copy_previous_notes, '&nbsp;'.html_safe) do
+          = action_button(t('.copy_previous_notes'), '#', :copy)
+      #vorheriger-kommentar.hidden
+        = previous_entry.aufteilung_kontengruppen
+
+  = cost_accounting_input_fields(f, :abgrenzung_fibu)
+
+  - unless report == fp_class('CostAccounting::Report::DirekteSpendenAusserhalb')
+    - factor = report == fp_class('CostAccounting::Report::IndirekteSpenden') ? table.value_of(report.key, 'abgrenzung_factor') : nil
+    = f.labeled(:aufwand_ertrag_ko_re, report.aufwand ? t('.aufwand_ko_re') : t('.ertrag_ko_re')) do
+      .mt-2#aufwand_ertrag_ko_re{data: { abgrenzung_factor: factor }}
+
+  - if (report.editable_fields & gemeinkosten_fields).present?
+    %h3= t('.gemeinkosten')
+    = cost_accounting_input_fields(f, *gemeinkosten_fields)
+    = f.labeled(:gemeinkosten) do
+      .mt-2#gemeinkosten
+
+  - if (report.editable_fields & section_fields).present?
+    %h3= t('.kostentraeger')
+    = cost_accounting_input_and_course_fields(f, *section_fields)
+
+    = f.labeled(:kostentraeger) do
+      .mt-2#kostentraeger
+
+  - if (report.editable_fields & (section_fields + gemeinkosten_fields)).present?
+    %hr/
+    = f.labeled(:kontrolle) do
+      .mt-2#control_value
+
+- content_for(:javascripts) do
+  new App.CostAccountingCalculator().updateValues();
+  new App.CostAccountingNoteCopier().bind();

--- a/app/views/fp2024/course_reporting/aggregations/index.html.haml
+++ b/app/views/fp2024/course_reporting/aggregations/index.html.haml
@@ -1,0 +1,23 @@
+-#  Copyright (c) 2015, insieme Schweiz. This file is part of
+-#  hitobito_insieme and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito_insieme.
+
+- @subtitle = t('.title')
+
+%h3= t('activerecord.attributes.event/course.leistungskategorien.bk', count: 3)
+= course_aggregation_csv_button(lk: :bk)
+= course_aggregation_csv_button(lk: :bk, subsidized: false)
+
+%h3= t('activerecord.attributes.event/course.leistungskategorien.tk', count: 3)
+= course_aggregation_csv_button(lk: :tk)
+= course_aggregation_csv_button(lk: :tk, subsidized: false)
+
+%h3= t('activerecord.attributes.event/course.leistungskategorien.sk', count: 3)
+= course_aggregation_csv_button(lk: :sk)
+= course_aggregation_csv_button(lk: :sk, subsidized: false)
+
+%h3= t('activerecord.attributes.event/course.leistungskategorien.tp', count: 3)
+= course_aggregation_csv_button(lk: :tp)
+= course_aggregation_csv_button(lk: :tp, subsidized: false)
+

--- a/app/views/fp2024/event/course_records/_evaluation_fields.html.haml
+++ b/app/views/fp2024/event/course_records/_evaluation_fields.html.haml
@@ -1,0 +1,29 @@
+-#  Copyright (c) 2012-2014, insieme Schweiz. This file is part of
+-#  hitobito_insieme and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito_insieme.
+
+= field_set_tag(t('event.course_records.form.auswertungen')) do
+
+  = f.labeled_readonly_value :total_direkte_kosten,
+                             value: format_money(entry.direkter_aufwand)
+  = f.labeled_readonly_value :gemeinkostenanteil,
+                             value: gemeinkostenanteil_with_updated_at(entry)
+  = f.labeled_readonly_value :total_vollkosten,
+                             value: format_money(entry.total_vollkosten)
+  - if entry.tp?
+    = f.labeled_readonly_value :betreuungsstunden,
+                               value: fnumber(entry.betreuungsstunden),
+                               label: t('event.course_records.form.betreuungsstunden')
+    = f.labeled_readonly_value :vollkosten_pro_betreuungsstunde,
+                               value: format_money(entry.vollkosten_pro_betreuungsstunde),
+                               label: t('vollkosten_pro_betreuungsstunde', scope: fp_i18n_scope)
+  - else
+    = f.labeled_readonly_value :anzahl_le,
+                               value: fnumber(entry.total_tage_teilnehmende)
+    = f.labeled_readonly_value :vollkosten_pro_le,
+                               value: format_money(entry.vollkosten_pro_le)
+
+    - unless entry.event.is_a?(Event::Course) || entry.event.is_a?(Event::AggregateCourse)
+      = f.labeled_readonly_value :zugeteilte_kategorie,
+                                 value: zugeteilte_kategorie_with_info(entry)

--- a/app/views/fp2024/event/course_records/_main_fields.html.haml
+++ b/app/views/fp2024/event/course_records/_main_fields.html.haml
@@ -1,0 +1,30 @@
+-#  Copyright (c) 2012-2014, insieme Schweiz. This file is part of
+-#  hitobito_insieme and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito_insieme.
+
+- if entry.event.leistungskategorie.present?
+  = f.fields_for(:event, f.object.event) do |ef|
+    = ef.labeled_readonly_value(:leistungskategorie)
+    - unless tp
+      = ef.labeled_collection_select(:fachkonzept,
+                                    ef.object.class.available_kursfachkonzepte,
+                                    :first, :second, {prompt: true}, class: 'form-select form-select-sm')
+
+- if entry.event.is_a?(Event::AggregateCourse)
+  = f.labeled_input_field :anzahl_kurse, label: tp ? t(:anzahl_durchfuehrungen, scope: fp_i18n_scope) : nil
+
+= f.labeled_input_field :subventioniert
+
+- if !(sk || tp) && !(entry.event.is_a?(Event::Course) || entry.event.is_a?(Event::AggregateCourse))
+  = f.labeled(:inputkriterien) do
+    - [:a, :b, :c].each do |key|
+      = f.inline_radio_button(:inputkriterien, key, key.to_s.upcase)
+
+- unless tp || entry.event.is_a?(Event::Course) || entry.event.is_a?(Event::AggregateCourse)
+  = f.labeled(:kursart) do
+    - [:weiterbildung, :freizeit_und_sport].each do |key|
+      = f.inline_radio_button(:kursart, key, kursart_label(key))
+
+- if !(sk || tp)
+  = f.labeled_input_field :spezielle_unterkunft

--- a/app/views/fp2024/event/course_records/_team_fields.html.haml
+++ b/app/views/fp2024/event/course_records/_team_fields.html.haml
@@ -1,0 +1,26 @@
+-#  Copyright (c) 2020, insieme Schweiz. This file is part of
+-#  hitobito_insieme and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito_insieme.
+
+= field_set_tag(t('event.course_records.form.betreuerinnen')) do
+  - if entry.tp?
+    = participant_field_with_suggestion(f, :betreuerinnen, @numbers.caretaker_count)
+  - else
+    = participant_field_with_suggestion(f, :leiterinnen, @numbers.leader_count)
+    = participant_field_with_suggestion(f, :fachpersonen, @numbers.expert_count)
+    = participant_field_with_suggestion(f, :hilfspersonal_mit_honorar, @numbers.helper_paid_count)
+    = participant_field_with_suggestion(f, :hilfspersonal_ohne_honorar, @numbers.helper_unpaid_count)
+
+    = participant_readonly_value_with_suggestion(f, :total, fnumber(entry.betreuende), fnumber(@numbers.team_count))
+
+  = f.labeled_readonly_value :betreuungsschluessel,
+                              value: t('event.course_records.form.challenged_per_team', ratio: f(entry.betreuungsschluessel))
+
+- if entry.event.is_a?(::Event::AggregateCourse) && entry.tp?
+  = field_set_tag(t('event.course_records.form.total_betreuungsstunden')) do
+    = f.labeled_input_field :betreuungsstunden, addon: t('global.hours_short')
+
+- unless entry.tp?
+  = field_set_tag(t('event.course_records.form.personal')) do
+    = participant_field_with_suggestion(f, :kuechenpersonal, @numbers.kitchen_count)

--- a/app/views/fp2024/event/general_cost_allocations/edit.html.haml
+++ b/app/views/fp2024/event/general_cost_allocations/edit.html.haml
@@ -1,0 +1,49 @@
+-#  Copyright (c) 2020, insieme Schweiz. This file is part of
+-#  hitobito_insieme and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito_insieme.
+
+- @subtitle = I18n.t('crud.edit.title', model: entry)
+
+= reporting_frozen_message
+
+%p
+  = action_button(t('.export'),
+                  general_cost_allocation_group_events_path(group, year, format: :csv),
+                  :download)
+
+= crud_form(entry,
+            url: general_cost_allocation_group_events_path(group, year),
+            cancel_url: general_cost_allocation_group_events_path(group, year),
+            buttons_top: false,
+            buttons_bottom: !reporting_frozen?,
+            submit_label: t('.start_allocation'),
+            method: :put,
+            html: { class: 'report', data: { readonly: reporting_frozen? } }) do |f|
+
+  = render 'leistungskategorie_fields',
+           f: f,
+           caption: t('.blockkurse'),
+           field: :general_costs_blockkurse,
+           lk: 'bk'
+
+  = render 'leistungskategorie_fields',
+           f: f,
+           caption: t('.tageskurse'),
+           field: :general_costs_tageskurse,
+           lk: 'tk'
+
+  = render 'leistungskategorie_fields',
+           f: f,
+           caption: t('.semesterkurse'),
+           field: :general_costs_semesterkurse,
+           lk: 'sk'
+
+  = render 'leistungskategorie_fields',
+           f: f,
+           caption: t('.treffpunkte'),
+           field: :general_costs_treffpunkte,
+           lk: 'tp'
+
+
+%p= t('.last_allocation', date: format_attr(entry, :updated_at)).html_safe

--- a/app/views/fp2024/time_records/_lufeb_fields_full.html.haml
+++ b/app/views/fp2024/time_records/_lufeb_fields_full.html.haml
@@ -1,0 +1,39 @@
+= field_set_tag(t('fp2020.time_records.lufeb_grundlagen')) do
+  = f.labeled_fp_input_field :lufeb_grundlagen, addon: t('global.hours_short')
+
+= field_set_tag(t('fp2020.time_records.lufeb_promoting')) do
+  = f.labeled_fp_input_field :beratung_fachhilfeorganisationen, addon: t('global.hours_short')
+  = f.labeled_fp_input_field :unterstuetzung_leitorgane, addon: t('global.hours_short')
+  = f.labeled_fp_input_field :freiwilligen_akquisition, addon: t('global.hours_short')
+
+  = f.labeled_readonly_value :total_lufeb_promoting, label: t('.subtotal'), value: format_hours(entry.total_lufeb_promoting)
+
+= field_set_tag(t('fp2020.time_records.lufeb_general')) do
+  = f.labeled_fp_input_field :auskuenfte, addon: t('global.hours_short')
+  = f.labeled_fp_input_field :referate, addon: t('global.hours_short')
+  = f.labeled_fp_input_field :medien_zusammenarbeit, addon: t('global.hours_short')
+  = f.labeled_fp_input_field :sensibilisierungskampagnen, addon: t('global.hours_short')
+
+  = f.labeled_readonly_value :total_lufeb_general, label: t('.subtotal'), value: format_hours(entry.total_lufeb_general)
+
+= field_set_tag(t('fp2020.time_records.lufeb_specific')) do
+  = f.labeled_fp_input_field :erarbeitung_grundlagen, addon: t('global.hours_short')
+  = f.labeled_fp_input_field :gremien, addon: t('global.hours_short')
+  = f.labeled_fp_input_field :vernehmlassungen, addon: t('global.hours_short')
+  = f.labeled_fp_input_field :projekte, addon: t('global.hours_short')
+
+  = f.labeled_readonly_value :total_lufeb_specific, label: t('.subtotal'), value: format_hours(entry.total_lufeb_specific)
+
+= field_set_tag do
+  = f.labeled_readonly_value :total_lufeb, value: format_hours(entry.total_lufeb)
+
+%h2= fp_t('media')
+= field_set_tag do
+  = f.labeled_fp_input_field :medien_grundlagen, addon: t('global.hours_short')
+  = f.labeled_fp_input_field :website, addon: t('global.hours_short')
+  = f.labeled_fp_input_field :newsletter, addon: t('global.hours_short')
+  = f.labeled_fp_input_field :videos, addon: t('global.hours_short')
+  = f.labeled_fp_input_field :social_media, addon: t('global.hours_short')
+  = f.labeled_fp_input_field :beratungsmodule, addon: t('global.hours_short')
+  = f.labeled_fp_input_field :apps, addon: t('global.hours_short')
+  = f.labeled_readonly_value :total_media, label: t('.subtotal'), value: format_hours(entry.total_media)

--- a/app/views/fp2024/time_records/_lufeb_fields_sumarized.html.haml
+++ b/app/views/fp2024/time_records/_lufeb_fields_sumarized.html.haml
@@ -1,0 +1,14 @@
+= field_set_tag do
+  = f.labeled_fp_input_field :lufeb_grundlagen, addon: t('global.hours_short')
+  = f.labeled_fp_input_field :total_lufeb_promoting, addon: t('global.hours_short')
+  = f.labeled_input_field :total_lufeb_general, addon: t('global.hours_short')
+  = f.labeled_input_field :total_lufeb_specific, addon: t('global.hours_short')
+
+= field_set_tag do
+  = f.labeled_readonly_value :total_lufeb, value: format_hours(entry.total_lufeb)
+
+%h2= fp_t('media')
+= field_set_tag do
+  = f.labeled_input_field :total_media, label: fp_t('lufeb_fields_sumarized.total_media'),
+                                        addon: t('global.hours_short')
+  = f.labeled_readonly_value :total_media, label: t('.total'), value: format_hours(entry.total_media)

--- a/app/views/fp2024/time_records/edit.html.haml
+++ b/app/views/fp2024/time_records/edit.html.haml
@@ -1,0 +1,69 @@
+-#  Copyright (c) 2012-2014, insieme Schweiz. This file is part of
+-#  hitobito_insieme and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito_insieme.
+
+- title(I18n.t('crud.edit.title', model: entry))
+
+= reporting_frozen_message
+
+= crud_form(entry,
+            url: time_record_report_group_path(group, year, entry.class.key),
+            cancel_url: time_record_base_information_group_path(group, year: year),
+            buttons_top: !reporting_frozen?,
+            buttons_bottom: !reporting_frozen?,
+            method: :put,
+            html: { class: 'long-labeled report', data: { readonly: reporting_frozen? } }) do |f|
+
+  %p= t('.comment')
+
+  - if entry.class.key == 'employee_time'
+    %h2= t('.employees')
+    = f.fields_for(:employee_pensum) do |nf|
+      = nf.labeled_input_field :paragraph_74, help_inline: t('.help_employee_pensum')
+      = nf.labeled_input_field :not_paragraph_74
+      = f.labeled_readonly_value :total_employee_pensum, label: t('.total'), value: fnumber(entry.employee_pensum.total)
+
+  %h2= t('.lufeb')
+  - if entry.class.key == 'volunteer_without_verification_time'
+    = render 'lufeb_fields_sumarized', f: f
+  - else
+    = render 'lufeb_fields_full', f: f
+
+  %h2= fp_t('.courses')
+  = field_set_tag do
+    = f.labeled_fp_input_field :kurse_grundlagen, addon: t('global.hours_short')
+    = f.labeled_input_field :blockkurse, addon: t('global.hours_short')
+    = f.labeled_input_field :tageskurse, addon: t('global.hours_short')
+    = f.labeled_input_field :jahreskurse, addon: t('global.hours_short')
+    = f.labeled_input_field :treffpunkte_grundlagen, addon: t('global.hours_short')
+    = f.labeled_fp_input_field :treffpunkte, addon: t('global.hours_short')
+    = f.labeled_readonly_value :total_courses, label: t('.total'), value: format_hours(entry.total_courses)
+
+  %h2= fp_t('.beratung')
+  = field_set_tag do
+    = f.labeled_fp_input_field :beratung, addon: t('global.hours_short')
+    = f.labeled_readonly_value :total_additional_person_specific, label: t('.total'), value: format_hours(entry.total_additional_person_specific)
+
+  %h2= t('.remaining')
+  = field_set_tag do
+    = f.labeled_input_field :mittelbeschaffung, addon: t('global.hours_short')
+    = f.labeled_input_field :verwaltung, addon: t('global.hours_short')
+    = f.labeled_readonly_value :total_remaining, label: t('.total'), value: format_hours(entry.total_remaining)
+
+  = field_set_tag do
+    = f.labeled_readonly_value :total_paragraph_74, value: format_hours(entry.total_paragraph_74)
+    = f.labeled_readonly_value :total_paragraph_74_pensum, value: fnumber(entry.total_paragraph_74_pensum)
+
+  %h2= t('.not_paragraph_74')
+  = field_set_tag do
+    = f.labeled_input_field :nicht_art_74_leistungen, addon: t('global.hours_short')
+
+  = field_set_tag do
+    = f.labeled_readonly_value :total_not_paragraph_74, value: format_hours(entry.total_not_paragraph_74)
+    = f.labeled_readonly_value :total_not_paragraph_74_pensum, value: fnumber(entry.total_not_paragraph_74_pensum)
+
+  %h2= t('.whole_organization')
+  = field_set_tag do
+    = f.labeled_readonly_value :total, value: format_hours(entry.total)
+    = f.labeled_readonly_value :total_pensum, value: fnumber(entry.total_pensum)

--- a/config/locales/models.insieme.de.yml
+++ b/config/locales/models.insieme.de.yml
@@ -793,8 +793,9 @@ de:
         fund_building: Bildung gebundener Fonds aus freien Mitteln
         exemption: abzüglich Freibetrag
         capital_substrate_allocated: Geschlüsseltes Kapitalsubstrat Art. 74
-        deckungsbeitrag4_fp2015: Summe der DB4 von 2015-2019
+        deckungsbeitrag4_fp2015: Summe der DB4 der Vertragsperiode 2015-2019
         deckungsbeitrag4_fp2020: Summe der DB4 der Vertragsperiode 2020-2023
+        deckungsbeitrag4_fp2024: Summe der DB4 der Vertragsperiode 2024-2027
         deckungsbeitrag4_sum: Summe der DB4 von 2015 bis %{year}
         iv_finanzierungsgrad_since_2015: IV Finanzierungsgrad seit 2015
         iv_finanzierungsgrad_fp2015: IV Finanzierungsgrad 2015 - 2019

--- a/config/locales/models.insieme.de.yml
+++ b/config/locales/models.insieme.de.yml
@@ -800,6 +800,7 @@ de:
         iv_finanzierungsgrad_since_2015: IV Finanzierungsgrad seit 2015
         iv_finanzierungsgrad_fp2015: IV Finanzierungsgrad 2015 - 2019
         iv_finanzierungsgrad_fp2020: IV Finanzierungsgrad 2020 - 2023
+        iv_finanzierungsgrad_fp2024: IV Finanzierungsgrad 2024 - 2027
         iv_finanzierungsgrad_current: aktueller IV Finanzierungsgrad
 
     errors:

--- a/config/locales/models.insieme.fr.yml
+++ b/config/locales/models.insieme.fr.yml
@@ -795,8 +795,9 @@ fr:
         fund_building: Formation des fonds liés provenant des liquidités libres
         exemption: Montant libre déduit
         capital_substrate_allocated: Substrat de capital codé art. 74
-        deckungsbeitrag4_fp2015: Somme des CC4 de 2015-2019
-        deckungsbeitrag4_fp2020: Somme des CC4 de la durée contractuelle de 2020-2023
+        deckungsbeitrag4_fp2015: Somme des CC4 du contrat de 2015-2019
+        deckungsbeitrag4_fp2020: Somme des CC4 du contrat de 2020-2023
+        deckungsbeitrag4_fp2024: Somme des CC4 du contrat de 2024-2027
         deckungsbeitrag4_sum: Somme des CC 4 2015 à %{year}
         iv_finanzierungsgrad_since_2015: Taux de financement AI depuis 2015
         iv_finanzierungsgrad_fp2015: Taux de financement AI 2015 - 2019

--- a/config/locales/models.insieme.fr.yml
+++ b/config/locales/models.insieme.fr.yml
@@ -802,6 +802,7 @@ fr:
         iv_finanzierungsgrad_since_2015: Taux de financement AI depuis 2015
         iv_finanzierungsgrad_fp2015: Taux de financement AI 2015 - 2019
         iv_finanzierungsgrad_fp2020: Taux de financement AI 2020 - 2023
+        iv_finanzierungsgrad_fp2024: Taux de financement AI 2024 - 2027
         iv_finanzierungsgrad_current: Taux de financement AI actuel
 
     errors:

--- a/config/locales/views.insieme.de.yml
+++ b/config/locales/views.insieme.de.yml
@@ -699,6 +699,155 @@ de:
       total_media: Medien & Publikationen
       beratung: Sozialberatung
 
+  fp2024:
+    cost_accounting:
+      report:
+        total_umlagen:
+          name: Gemeinkosten
+          short_name: Gemeinkosten
+        unternehmenserfolg:
+          name: Ertrag minus Aufwand
+          short_name: Ertrag minus Aufwand
+        deckungsbeitrag4:
+          name: Deckungsbeitrag 4
+          short_name: Deckungsbeitrag 4
+      headers:
+        beratung: Sozialberatung
+      beratung: Sozialberatung
+      pro_verein:
+        # row-labels
+        type: Kostenarten
+        personalaufwand: Personalaufwand
+        honorare: Honorare
+        sachaufwand: Sachaufwand
+        aufwand: Aufwand
+        gemeinkosten: Gemeinkosten # also a column-label
+        umlagen: Umlagen
+        total_aufwand: Total Aufwand & Umlagen
+        leistungen: Leistungen
+        beitraege_iv: Beiträge IV/AHV
+        sonstige_beitraege: Sonstige Beiträge Bund/Kant./Geme.
+        spenden_zweckgebunden: zweckgeb. Spenden/sonstige Erträge
+        spenden_nicht_zweckgebunden: nicht zweckgeb. Spenden/sonstige Erträge
+
+        # column-labels
+        aufwand_ertrag_fibu: FiBu - KLR
+        abgrenzung: Abgrenzung
+        klr: KLR
+        sozialberatung: Sozialberatung
+        bauberatung: Bauberatung
+        rechtsberatung: Rechtsberatung
+        vermittlung: Vermittlung Betreuung
+        wohnbegleitung: Begleitetes Wohnen
+        media: Medien und Publikationen
+        jahreskurse: Semester-/Jahreskurse
+        blockkurse: Blockkurse
+        tageskurse: Tageskurse
+        treffpunkte: Treffpunkte
+        lufeb: LUFEB
+
+    course_records:
+      vollkosten_pro_betreuungsstunde: Vollkosten pro Betreuungsstunde
+      anzahl_durchfuehrungen: Anzahl Durchführungen
+    course_reporting:
+      aggregations:
+        anzahl_kurse_tp: Anzahl Durchführungen
+        betreuende_tp: Betreuungspersonen
+        direkte_kosten_pro_betreuungsstunde: Durchschnittliche direkte Kosten pro Betreuungsstunde
+        vollkosten_pro_betreuungsstunde: Durchschnittliche Vollkosten pro Betreuungsstunde
+      client_statistics:
+        group_or_course_type: Verein / Kurstyp
+        course_count: Anzahl Kurse
+        course_hours: LE Beitragsberechtigte
+        other_attendees: LE Nicht Beitragsberechtigte
+        course_total: Total
+        course_fachkonzept: Kursinhalt
+        fachkonzept:
+          weiterbildung: Weiterbildung
+          sport: Sport/Freizeit
+          treffpunkt: Treffpunkt
+    events:
+      anzahl_durchfuehrungen: Anzahl Durchführungen
+    statistics:
+      group_figures:
+        anzahl_kurse: "%{leistungskategorie} Anzahl Kurse %{fachkonzept}"
+        total_vollkosten: "%{leistungskategorie} Total Vollkosten %{fachkonzept}"
+        tage_behinderte: "%{leistungskategorie} TN Tage Personen mit Behinderung %{fachkonzept}"
+        tage_angehoerige: "%{leistungskategorie} TN Tage Angehörige %{fachkonzept}"
+        tage_weitere: "%{leistungskategorie} TN Tage nicht Bezugsberechtigte %{fachkonzept}"
+        tage_total: "%{leistungskategorie} TN Tage Total %{fachkonzept}"
+        betreuungsstunden_total: "%{leistungskategorie} Betreuungsstunden Total %{fachkonzept}"
+        hours_employees: Stunden Angestellte
+        hours_volunteers: Stunden Ehrenamtliche mit Leistungsausweis
+        hours_volunteers_without: Stunden Ehrenamtliche ohne Leistungsausweis
+    time_records:
+      lufeb_grundlagen: Grundlagenarbeit zu LUFEB
+
+      lufeb_promoting: Förderung der Selbsthilfe
+      beratung_fachhilfeorganisationen: Information / Beratung von Organisationen und Einzelpersonen
+      unterstuetzung_leitorgane: Unterstützung von Menschen mit Behinderungen in Leitorganen
+      freiwilligen_akquisition: Akquisition von Freiwilligen
+      total_lufeb_promoting: Förderung der Selbsthilfe
+
+      lufeb_general: Allgemeine Medien & Öffentlichkeitsarbeit
+      auskuenfte: Auskünfte an die Öffentlichkeit, Menschen mit Behinderung, Angehörige, Fachpersonen, Medien
+      referate: Vorträge / Referate
+      medien_zusammenarbeit: Zusammenarbeit mit Medien
+      sensibilisierungskampagnen: Sensibilisierungs- und Entstigmatisierungsarbeiten resp. -veranstaltungen
+
+      lufeb_specific: Themenspezifische Grundlagenarbeit
+      erarbeitung_grundlagen: Grundlagenarbeit (Arbeitsinstrumente, Konzepte, Studien, Grundlagenpapiere)
+      gremien: Mitgliedschaft / Mitarbeit in Gremien
+      vernehmlassungen: Mitarbeit bei Vernehmlassungen
+      projekte: Projekte Art. 74 (Vorbereitung und Durchführung)
+
+      media: Medien & Publikationen
+      medien_grundlagen: Grundlagenarbeit zu Medien & Publikationen
+      website: Website
+      newsletter: Rundbriefe, Broschüren, Merkblätter
+      videos: Videos
+      social_media: Soziale Medien
+      beratungsmodule: Standardisierte Beratungsmodule
+      apps: Applikationen
+      total_media: Medien & Publikationen
+
+      treffpunkte: Treffpunkte
+      treffpunkte_grundlagen: Grundlagenarbeit zu Treffpunkten
+      kurse_grundlagen: Grundlagenarbeit zu Kursen
+      beratung: Sozialberatung (inkl. Grundlagenarbeit)
+      total_courses: Total Kurse & Treffpunkte
+      edit:
+        courses: Kurse & Treffpunkte
+        beratung: Sozialberatung
+
+      lufeb_fields_sumarized:
+        total_media: Medien & Publikationen (inkl. Grundlagenarbeit)
+
+      lufeb_times:
+        group_or_stat: Gruppe/Feldname
+        general: Allgemeine Medien & Öffentlichkeitsarbeit
+        specific_with_grundlagen: Themenspezifische Grundlagenarbeit
+        promoting: Förderung der Selbsthilfe
+
+      group_data:
+        group_or_stat: Gruppe/Feldname
+        angestellte_insgesamt: FTE Angestellte MA insgesamt
+        angestellte_art_74: FTE Angestellte MA Betrieb Art. 74 IVG
+        freiwillige_insgesamt: FTE Freiwillig und ehrenamtlich Mitarbeitende insgesamt
+        freiwillige_art_74: FTE Freiwillig und ehrenamtlich Mitarbeitende des Betriebes Art. 74 IVG
+
+    lufeb_fields_full:
+      lufeb_grundlagen: Grundlagenarbeit zu LUFEB
+      lufeb_promoting: Förderung der Selbsthilfe
+      lufeb_general: Allgemeine Medien & Öffentlichkeitsarbeit
+      lufeb_specific: Themenspezifische Grundlagenarbeit
+    fields_full:
+      kurse_grundlagen: Grundlagenarbeit Kurse
+      treffpunkte_grundlagen: Grundlagenarbeit Treffpunkte
+      media_grundlagen: Grundlagenarbeit Medien & Publikationen
+      total_media: Medien & Publikationen
+      beratung: Sozialberatung
+
   export/tabular/events:
     title: Kurse
 
@@ -830,6 +979,58 @@ de:
     date: "Datum %{index}"
 
   fp2022/export/tabular/events/aggregate_course/detail_list:
+    group_names: "Organisatoren"
+    duration: Zeitraum
+    date: "Datum %{index}"
+    teilnehmende_behinderte: Effektiv Teilnehmende Personen mit Behinderung
+    teilnehmende_angehoerige: Effektiv Teilnehmende Angehörige
+    teilnehmende_mehrfachbehinderte: Effektiv Teilnehmende Mehrfachbehinderte
+    teilnehmende_weitere: Effektiv Teilnehmende Weitere, nicht Beitragsberechtigt
+    absenzen_behinderte: Absenzen Personen mit Behinderung
+    absenzen_angehoerige: Absenzen Angehörige
+    absenzen_weitere: Absenzen Weitere, nicht Beitragsberechtigt
+    tage_behinderte: Total TeilnehmerInnentage Personen mit Behinderung
+    tage_angehoerige: Total TeilnehmerInnentage Angehörige
+    tage_weitere: Total TeilnehmerInnentage Weitere, nicht Beitragsberechtigt
+    total_tage_teilnehmende: Anzahl tatsächliche LE
+    direkter_aufwand: Direkter Aufwand
+    betreuerinnen: Betreuungspersonen
+    anzahl_kurse: Anzahl Kurse / Durchführungen
+    total_stunden_betreuung: Total Betreuungsstunden
+    vollkosten_pro_betreuungsstunde: Vollkosten/Betreuungsstunde
+
+  fp2024/export/tabular/events/short_list:
+    group_names: "Organisatoren"
+    duration: Zeitraum
+    date: "Datum %{index}"
+
+  fp2024/export/tabular/events/detail_list:
+    group_names: "Organisatoren"
+    duration: Zeitraum
+    date: "Datum %{index}"
+    teilnehmende_behinderte: Effektiv Teilnehmende Personen mit Behinderung
+    teilnehmende_angehoerige: Effektiv Teilnehmende Angehörige
+    teilnehmende_mehrfachbehinderte: Effektiv Teilnehmende Mehrfachbehinderte
+    teilnehmende_weitere: Effektiv Teilnehmende Weitere, nicht Beitragsberechtigt
+    absenzen_behinderte: Absenzen Personen mit Behinderung
+    absenzen_angehoerige: Absenzen Angehörige
+    absenzen_weitere: Absenzen Weitere, nicht Beitragsberechtigt
+    tage_behinderte: Total TeilnehmerInnentage Personen mit Behinderung
+    tage_angehoerige: Total TeilnehmerInnentage Angehörige
+    tage_weitere: Total TeilnehmerInnentage Weitere, nicht Beitragsberechtigt
+    total_tage_teilnehmende: Anzahl tatsächliche LE
+    direkter_aufwand: Direkter Aufwand
+    betreuerinnen: Betreuungspersonen
+    anzahl_kurse: Anzahl Kurse / Durchführungen
+    total_stunden_betreuung: Total Betreuungsstunden
+    vollkosten_pro_betreuungsstunde: Vollkosten/Betreuungsstunde
+
+  fp2024/export/tabular/events/aggregate_course/short_list:
+    group_names: "Organisatoren"
+    duration: Zeitraum
+    date: "Datum %{index}"
+
+  fp2024/export/tabular/events/aggregate_course/detail_list:
     group_names: "Organisatoren"
     duration: Zeitraum
     date: "Datum %{index}"

--- a/config/locales/views.insieme.de.yml
+++ b/config/locales/views.insieme.de.yml
@@ -45,6 +45,7 @@ de:
       iv_finanzierungsgrad_since_2015: Durchschnittlicher IV Finanzierungsgrad 2015 - %{year}
       iv_finanzierungsgrad_fp2015: Durchschnittlicher IV Finanzierungsgrad 2015 - 2019
       iv_finanzierungsgrad_fp2020: Durchschnittlicher IV Finanzierungsgrad 2020 - 2023
+      iv_finanzierungsgrad_fp2024: Durchschnittlicher IV Finanzierungsgrad 2024 - 2027
       iv_finanzierungsgrad_current: IV Finanzierungsgrad %{year}
       help_per_date: per %{date}
 

--- a/config/locales/views.insieme.fr.yml
+++ b/config/locales/views.insieme.fr.yml
@@ -42,10 +42,11 @@ fr:
     edit:
       deckungsbeitrag4_sum_notice: "Remarque: Pour les associations ayant une contribution AI inférieure à 300'000.00 fr., les CC4 cumulées depuis 2015 sont prises en compte dans le calcul du substrat de capital."
       deckungsbeitrag4_sum: Somme des CC 4 2015 à %{year}
-      iv_finanzierungsgrad_since_2015: Taux de financement AI moyen 2015
+      iv_finanzierungsgrad_since_2015: Taux de financement AI moyen 2015 - %{year}
       iv_finanzierungsgrad_fp2015: Taux de financement AI moyen 2015 - 2019
       iv_finanzierungsgrad_fp2020: Taux de financement AI moyen 2020 - 2023
-      iv_finanzierungsgrad_current: Taux de financement AI
+      iv_finanzierungsgrad_fp2024: Taux de financement AI moyen 2024 - 2027
+      iv_finanzierungsgrad_current: Taux de financement AI %{year}
       help_per_date: en %{date}
 
   contactable:

--- a/config/locales/views.insieme.fr.yml
+++ b/config/locales/views.insieme.fr.yml
@@ -701,6 +701,155 @@ fr:
       total_media: Médias & publications
       beratung: Conseil social
 
+  fp2024:
+    cost_accounting:
+      report:
+        total_umlagen:
+          name: Frais généraux
+          short_name: Frais généraux
+        unternehmenserfolg:
+          name: Produits moins charges
+          short_name: Produits moins charges
+        deckungsbeitrag4:
+          name: Contributions de couverture 4
+          short_name: Contributions de couverture 4
+      headers:
+        beratung: Conseil social
+      beratung: Conseil social
+      pro_verein:
+        # row-labels
+        type: Types de frais
+        personalaufwand: Charges de personnel
+        honorare: Honoraires
+        sachaufwand: Charges matérielles
+        aufwand: Charges
+        gemeinkosten: Frais généraux # also a column-label
+        umlagen: Répartitions
+        total_aufwand: Total des charges & répartitions
+        leistungen: Prestations
+        beitraege_iv: Contributions AI/AVS
+        sonstige_beitraege: Autres contributions fédérales/cantonales/communales
+        spenden_zweckgebunden: dons affectés/autres revenus
+        spenden_nicht_zweckgebunden: dons non affectés/autres revenus
+
+        # column-labels
+        aufwand_ertrag_fibu: CF - CA
+        abgrenzung: Délimitation
+        klr: CA
+        sozialberatung: Conseil social
+        bauberatung: Conseil en matière de construction
+        rechtsberatung: Conseil juridique
+        vermittlung: Mise en relation avec des services d’aide
+        wohnbegleitung: Accompagnement à domicile
+        media: Médias et publications
+        jahreskurse: Cours semestriels / annuels
+        blockkurse: Cours en bloc
+        tageskurse: Cours journaliers
+        treffpunkte: Lieux d’accueil
+        lufeb: PROSPREH
+
+    course_records:
+      vollkosten_pro_betreuungsstunde: Coûts complets par heure d’accompagnement
+      anzahl_durchfuehrungen: Nombre de réalisations
+    course_reporting:
+      aggregations:
+        anzahl_kurse_tp: Nombre de réalisations
+        betreuende_tp: Personnel d'encadrement
+        direkte_kosten_pro_betreuungsstunde: Frais directs moyens par heure d’accompagnement
+        vollkosten_pro_betreuungsstunde: Frais complets moyens par heure d’accompagnement
+      client_statistics:
+        group_or_course_type: Association / Type de cours
+        course_count: Nombre de cours
+        course_hours: Unité de prestation ayant droit à une contribution
+        other_attendees: Unité de prestation non ayant droit à une contribution
+        course_total: Total
+        course_fachkonzept: Contenu du cours
+        fachkonzept:
+          weiterbildung: Formation continue
+          sport: Sport/loisirs
+          treffpunkt: Lieux d’accueil
+    events:
+      anzahl_durchfuehrungen: Nombre de réalisations
+    statistics:
+      group_figures:
+        anzahl_kurse: "%{leistungskategorie} nombre de cours %{fachkonzept}"
+        total_vollkosten: "%{leistungskategorie} Total des frais complets %{fachkonzept}"
+        tage_behinderte: " Jours-participants personnes en situation de handicap"
+        tage_angehoerige: "%{leistungskategorie} Jours des participants proches %{fachkonzept}"
+        tage_weitere: "%{leistungskategorie} Jours des participants non bénéficiaires %{fachkonzept}"
+        tage_total: "%{leistungskategorie} Jours des participants total %{fachkonzept}"
+        betreuungsstunden_total: "%{leistungskategorie} heures d’accompagnement total %{fachkonzept}"
+        hours_employees: Heures employé*es
+        hours_volunteers: Heures de bénévolats avec certificat de performance
+        hours_volunteers_without: Heures de bénévolats sans certificat de performance
+    time_records:
+      lufeb_grundlagen: Travail de fond PROSPREH
+
+      lufeb_promoting: Encouragement de l’entraide
+      beratung_fachhilfeorganisationen: Information, conseil aux organisations et aux particuliers
+      unterstuetzung_leitorgane: Soutien aux personnes en situation de handicap dans les organes directeurs
+      freiwilligen_akquisition: Recrutement de bénévoles
+      total_lufeb_promoting: Encouragement de l’entraide
+
+      lufeb_general: Tâches générales d’information et de relations publiques
+      auskuenfte: Renseignements pour le public, les personnes en situation de handicap, les proches, les professionnels, les médias
+      referate: Présentations
+      medien_zusammenarbeit: Collaboration avec des médias
+      sensibilisierungskampagnen: Travaux et manifestations visant à sensibiliser le grand public et à lutter contre la stigmatisation
+
+      lufeb_specific: Travail de fond ayant pour objet un thème spécifique
+      erarbeitung_grundlagen: Travail de fond (instruments de travail, concepts, études, documents de base)
+      gremien: Appartenance / collaboration à des organes
+      vernehmlassungen: Participation à des procédures de consultation
+      projekte: Projets art. 74 LAI (préparation et réalisation)
+
+      media: Médias et publications
+      medien_grundlagen: Travail de fond sur les médias et les publications
+      website: Site web
+      newsletter: Lettres circulaires, brochures d’information, mémentos
+      videos: Vidéos
+      social_media: Médias sociaux
+      beratungsmodule: Module de conseil standardisé
+      apps: Applications
+      total_media: Médias et publications
+
+      treffpunkte: Lieux d'acceuil
+      treffpunkte_grundlagen: Travail de fond sur les lieux d'acceuil
+      kurse_grundlagen: Travail de fond sur les cours
+      beratung: Conseil social (incl. travail de fond)
+      total_courses: Total cours & lieux d'acceuil
+      edit:
+        courses: Cours & lieux d'acceuil
+        beratung: Conseil social
+
+      lufeb_fields_sumarized:
+        total_media: Médias et publications (incl. travail de fond)
+
+      lufeb_times:
+        group_or_stat: Groupe/nom de champ
+        general: Tâches générales d’information et de relations publiques
+        specific_with_grundlagen: Travail de fond ayant pour objet un thème spécifique
+        promoting: Encouragement de l’entraide
+
+      group_data:
+        group_or_stat: Groupe/nom de champ
+        angestellte_insgesamt: FTE Total des employé*es
+        angestellte_art_74: FTE employé*es exploitation au sens de l’art. 74 LAI
+        freiwillige_insgesamt: FTE Total bénévoles et volontaires
+        freiwillige_art_74: FTE Bénévoles et des volontaires de l'exploitation au sens de l’art. 74 LAI
+
+    lufeb_fields_full:
+      lufeb_grundlagen: Travail de fond PROSPREH
+      lufeb_promoting: Encouragement de l’entraide
+      lufeb_general: Tâches générales d’information et de relations publiques
+      lufeb_specific: 'Travail de fond ayant pour objet un thème spécifique '
+    fields_full:
+      kurse_grundlagen: Travail de fond cours
+      treffpunkte_grundlagen: Travail de fond lieux d'acceuil
+      media_grundlagen: Travail de fond médias & publications
+      total_media: Médias & publications
+      beratung: Conseil social
+
   export/tabular/events:
     title: Cours
 
@@ -832,6 +981,58 @@ fr:
     date: "Date %{index}"
 
   fp2022/export/tabular/events/aggregate_course/detail_list:
+    group_names: "Organisateurs"
+    duration: Période
+    date: "Date %{index}"
+    teilnehmende_behinderte: Participants effectifs personnes en situation de handicap
+    teilnehmende_angehoerige: Participants effectifs proches
+    teilnehmende_mehrfachbehinderte: Participants effectifs personnes en situation de polyhandicap
+    teilnehmende_weitere: Total des jours participants autres, non ayant droit à une contribution
+    absenzen_behinderte: Absences personnes en situation de handicap
+    absenzen_angehoerige: Absences proches
+    absenzen_weitere: Absences autres, non ayant droit à une contribution
+    tage_behinderte: Total des journées participants personnes en situation de handicap
+    tage_angehoerige: Total des jours participants proches
+    tage_weitere: Total des jours participants autres, non ayant droit à une contribution
+    total_tage_teilnehmende: Nombre effectif de unité de prestation
+    direkter_aufwand: Charges directes
+    betreuerinnen: Personnel d'encadrement
+    anzahl_kurse: Nombre de cours / réalisations
+    total_stunden_betreuung: Total heures d’accompagnement
+    vollkosten_pro_betreuungsstunde: Coûts complets par heure d’accompagnement
+
+  fp2024/export/tabular/events/short_list:
+    group_names: "Organisateurs"
+    duration: Période
+    date: "Date %{index}"
+
+  fp2024/export/tabular/events/detail_list:
+    group_names: "Organisateurs"
+    duration: Période
+    date: "Date %{index}"
+    teilnehmende_behinderte: Participants effectifs personnes en situation de handicap
+    teilnehmende_angehoerige: Participants effectifs proches
+    teilnehmende_mehrfachbehinderte: Participants effectifs personnes en situation de polyhandicap
+    teilnehmende_weitere: Total des jours participants autres, non ayant droit à une contribution
+    absenzen_behinderte: Absences personnes en situation de handicap
+    absenzen_angehoerige: Absences proches
+    absenzen_weitere: Absences autres, non ayant droit à une contribution
+    tage_behinderte: Total jours-participants personnes en situation de handicap
+    tage_angehoerige: Total des jours participants proches
+    tage_weitere: Total des jours participants autres, non ayant droit à une contribution
+    total_tage_teilnehmende: Nombre effectif de unité de prestation
+    direkter_aufwand: Charges directes
+    betreuerinnen: Personnel d'encadrement
+    anzahl_kurse: Nombre de cours / réalisations
+    total_stunden_betreuung: Total heures d’accompagnement
+    vollkosten_pro_betreuungsstunde: Coûts complets par heure d’accompagnement
+
+  fp2024/export/tabular/events/aggregate_course/short_list:
+    group_names: "Organisateurs"
+    duration: Période
+    date: "Date %{index}"
+
+  fp2024/export/tabular/events/aggregate_course/detail_list:
     group_names: "Organisateurs"
     duration: Période
     date: "Date %{index}"

--- a/spec/domain/featureperioden/dispatcher_spec.rb
+++ b/spec/domain/featureperioden/dispatcher_spec.rb
@@ -62,8 +62,12 @@ describe Featureperioden::Dispatcher do
       expect(described_class.new(2022).determine).to be 2022
     end
 
-    it "for 2023 and later, it is 2022" do
+    it "for 2023, it is 2022" do
       expect(described_class.new(2023).determine).to be 2022
+    end
+
+    it "for 2024 and later it is 2024" do
+      expect(described_class.new(2024).determine).to be 2024
     end
   end
 
@@ -74,7 +78,7 @@ describe Featureperioden::Dispatcher do
   # here, maybe add some performance-specs.
   context "is a sensible solution, it" do
     it "covers all periods" do
-      expect(described_class::KNOWN_BASE_YEARS).to have(3).items
+      expect(described_class::KNOWN_BASE_YEARS).to have(4).items
     end
   end
 end

--- a/spec/domain/fp2024/cost_accounting/aggregation_spec.rb
+++ b/spec/domain/fp2024/cost_accounting/aggregation_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024-2021, Insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require "spec_helper"
+
+describe Fp2024::CostAccounting::Aggregation do
+  let(:year) { 2024 }
+  subject { described_class.new(year) }
+
+  let(:values) { subject.reports.values }
+
+  context "has assumptions, it" do
+    it "does not blow up" do
+      expect(subject.year).to be 2024
+    end
+
+    it "has a used API, returning [Fp2024::CostAccounting::Aggregation::Report]" do
+      expect(values).to be_an Array
+      expect(values.first).to be_a Fp2024::CostAccounting::Aggregation::Report
+    end
+
+    it "has reports for each row (which then filtered in the export-class)" do
+      expected_report_keys = %w[
+        lohnaufwand
+        sozialversicherungsaufwand
+        uebriger_personalaufwand
+        honorare
+        total_personalaufwand
+        raumaufwand
+        uebriger_sachaufwand
+        abschreibungen
+        total_aufwand
+        umlage_personal
+        umlage_raeumlichkeiten
+        umlage_verwaltung
+        umlage_mittelbeschaffung
+        total_umlagen
+        vollkosten
+        leistungsertrag
+        beitraege_iv
+        sonstige_beitraege
+        direkte_spenden
+        indirekte_spenden
+        direkte_spenden_ausserhalb
+        total_ertraege
+        deckungsbeitrag1
+        deckungsbeitrag2
+        deckungsbeitrag3
+        unternehmenserfolg
+        deckungsbeitrag4
+      ]
+
+      actual_report_keys = subject.reports.keys
+
+      expect(actual_report_keys).to match_array expected_report_keys
+      expect(actual_report_keys).to eq expected_report_keys
+    end
+  end
+end

--- a/spec/domain/fp2024/cost_accounting/pro_verein_spec.rb
+++ b/spec/domain/fp2024/cost_accounting/pro_verein_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2021, Insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require "spec_helper"
+
+describe Fp2024::CostAccounting::ProVerein do
+  let(:year) { 2024 }
+  subject { described_class.new(year) }
+
+  let(:group) { groups(:dachverein) }
+
+  it "knows a list of groups to export" do
+    expected = [
+      "insieme Schweiz",
+      "Kanton Bern",
+      "Biel-Seeland",
+      "Freiburg"
+    ]
+
+    expect(subject.vereine.map(&:name)).to match_array expected
+    expect(subject.vereine.map(&:name)).to eq expected
+  end
+
+  it "has a structured data-object for all groups" do
+    list = subject.vereine.map { |verein| subject.data_for(verein) }
+
+    expect(list).to be_all Hash
+    expect(list.first.values).to be_all described_class::CostAccountingRow
+  end
+
+  context "has correct data" do
+    let(:data) { subject.data_for(group) }
+
+    it "judging by the hash-keys" do
+      expected = [
+        :personalaufwand,
+        :honorare,
+        :sachaufwand,
+        :aufwand,
+        :gemeinkosten,
+        :umlagen,
+        :total_aufwand,
+        :leistungen,
+        :beitraege_iv,
+        :sonstige_beitraege,
+        :spenden_zweckgebunden,
+        :spenden_nicht_zweckgebunden
+      ]
+
+      expected.each do |key|
+        expect(data).to have_key key
+      end
+    end
+
+    it "for gemeinkosten" do
+      expected = [nil, nil, nil, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      actual = data[:gemeinkosten].to_a
+
+      expect(actual).to match_array expected
+      expect(actual).to eq expected
+    end
+
+    it "for indirekte spenden" do
+      expected = [0.0, nil, nil, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      actual = data[:spenden_nicht_zweckgebunden].to_a
+
+      expect(actual).to match_array expected
+      expect(actual).to eq expected
+    end
+  end
+
+  describe Fp2024::CostAccounting::ProVerein::CostAccountingRow do
+    subject(:empty_row) { described_class.empty_row }
+
+    subject(:row) { described_class.new(*(1..10).to_a) }
+
+    it "can be empty" do
+      expect(described_class.empty_row).to be_a described_class
+    end
+
+    it "can be added together" do
+      expect(row).to respond_to(:+)
+      expect(row.aufwand_ertrag_fibu).to eq 1
+
+      sum = row + row
+      expect(sum).to be_a described_class
+      expect(sum.aufwand_ertrag_fibu).to eq 2
+    end
+
+    it "knows its members" do
+      expected = [
+        :aufwand_ertrag_fibu,
+        :abgrenzung,
+        :klr,
+        :gemeinkosten,
+        :sozialberatung,
+        :bauberatung,
+        :rechtsberatung,
+        :vermittlung,
+        :wohnbegleitung,
+        :media,
+        :jahreskurse,
+        :blockkurse,
+        :tageskurse,
+        :treffpunkte,
+        :lufeb
+      ]
+
+      expect(row.members).to match_array expected
+      expect(row.members).to eq expected
+    end
+
+    it "can remove values from a value" do
+      expect(row.gemeinkosten).to eq 3
+      expect(row.sozialberatung).to eq 4
+
+      nulled_row = row.nullify(:gemeinkosten)
+      expect(nulled_row).to be_a described_class
+      expect(nulled_row.gemeinkosten).to eq nil
+      expect(nulled_row.sozialberatung).to eq 4
+    end
+  end
+end

--- a/spec/domain/fp2024/cost_accounting/report/base_spec.rb
+++ b/spec/domain/fp2024/cost_accounting/report/base_spec.rb
@@ -1,0 +1,67 @@
+#  Copyright (c) 2024, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require "spec_helper"
+
+describe "CostAccounting::Report::Base" do
+  let(:year) { 2024 }
+  let(:group) { groups(:be) }
+  let(:table) { fp_class("CostAccounting::Table").new(group, year) }
+  let(:report) { fp_class("CostAccounting::Report::Lohnaufwand").new(table) }
+
+  before do
+    CostAccountingRecord.create!(group_id: group.id,
+      year: year,
+      report: "lohnaufwand",
+      aufwand_ertrag_fibu: 1000,
+      abgrenzung_fibu: 50)
+  end
+
+  context "#aufwand_ertrag_ko_re" do
+    it "is calculated correctly" do
+      expect(report.aufwand_ertrag_ko_re).to eq(950.0)
+    end
+  end
+
+  context "#total" do
+    it "is calculated correctly" do
+      expect(report.total).to eq(0.0)
+    end
+  end
+
+  context "#kontrolle" do
+    it "is calculated correctly" do
+      expect(report.kontrolle).to eq(-950.0)
+    end
+  end
+
+  context "basic accessors" do
+    it "return nil" do
+      expect(report.raeumlichkeiten).to be_nil
+    end
+  end
+
+  Fp2024::CostAccounting::Table::REPORTS.reject do |report|
+    report == Fp2024::CostAccounting::Report::Separator
+  end.each do |report|
+    context report.key do
+      it "is from the right Vertragsperiode" do
+        expect(report.name).to match(/^Fp#{year}::/)
+      end
+
+      it "has valid used fields" do
+        expect(report.used_fields - fp_class("CostAccounting::Report::Base")::FIELDS).to eq []
+      end
+
+      it "has valid editable fields" do
+        expect(report.editable_fields - report.used_fields - %w[aufteilung_kontengruppen]).to eq []
+      end
+
+      it "has human name" do
+        expect(report.human_name(year)).to match(/^[A-ZÖÄÜ]/)
+      end
+    end
+  end
+end

--- a/spec/domain/fp2024/cost_accounting/report/course_related_spec.rb
+++ b/spec/domain/fp2024/cost_accounting/report/course_related_spec.rb
@@ -1,0 +1,143 @@
+#  Copyright (c) 2024, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require "spec_helper"
+
+describe "CostAccounting::Report::CourseRelated" do
+  let(:group) { groups(:be) }
+  let(:table) { fp_class("CostAccounting::Table").new(group, year) }
+  let(:report) { table.reports.fetch("raumaufwand") }
+
+  context "based on courses" do
+    let(:year) { 2024 }
+
+    context "with cost accounting record" do
+      before do
+        CostAccountingRecord.create!(group_id: group.id,
+          year: year,
+          report: "raumaufwand",
+          aufwand_ertrag_fibu: 1050,
+          abgrenzung_fibu: 50)
+      end
+
+      context "with courses" do
+        before { create_course_records }
+
+        context "fields" do
+          it "works if present" do
+            expect(report.blockkurse).to eq 49000
+          end
+
+          it "works if nil" do
+            expect(report.jahreskurse).to be_nil
+          end
+        end
+
+        context "#total" do
+          it "is calculated correctly" do
+            expect(report.total).to eq(49050.0)
+          end
+        end
+      end
+
+      context "without courses" do
+        context "time fields" do
+          it "works if nil" do
+            expect(report.blockkurse).to be_nil
+          end
+        end
+
+        context "#total" do
+          it "is calculated correctly" do
+            expect(report.total).to eq(0.0)
+          end
+        end
+      end
+    end
+
+    context "without cost accounting record" do
+      before { create_course_records }
+
+      context "fields" do
+        it "work the same way" do
+          expect(report.blockkurse).to eq(49000)
+        end
+        it "work the same way if nil" do
+          expect(report.jahreskurse).to be_nil
+        end
+      end
+
+      context "#total" do
+        it "is calculated correctly" do
+          expect(report.total).to eq(49050.0)
+        end
+      end
+    end
+  end
+
+  context "based on manual values" do
+    let(:year) { 2024 }
+
+    before do
+      CostAccountingRecord.create!(group_id: group.id,
+        year: year,
+        report: "raumaufwand",
+        aufwand_ertrag_fibu: 1050,
+        abgrenzung_fibu: 50,
+        jahreskurse: 45_000,
+        tageskurse: 30)
+    end
+
+    before { create_course_records }
+
+    context "fields" do
+      it "works if present" do
+        expect(report.blockkurse).to eq 49_000
+      end
+
+      it "works if nil" do
+        expect(report.treffpunkte).to be_nil
+      end
+    end
+
+    context "#total" do
+      it "is calculated correctly" do
+        expect(report.total).to eq(49_050.0)
+      end
+    end
+  end
+
+  def create_course_records # rubocop:todo Metrics/MethodLength
+    Event::CourseRecord.create!(
+      event: Fabricate(:course,
+        groups: [group],
+        leistungskategorie: "bk", fachkonzept: "sport_jugend",
+        dates_attributes: [{start_at: Date.new(year, 10, 1)}]),
+      year: year,
+      unterkunft: 5000,
+      uebriges: 600
+    )
+    Event::CourseRecord.create!(
+      event: Fabricate(:aggregate_course, groups: [group], leistungskategorie: "bk",
+        fachkonzept: "sport_jugend", year: year),
+      unterkunft: 44000,
+      uebriges: 700
+    )
+    Event::CourseRecord.create!(
+      event: Fabricate(:aggregate_course, groups: [group], leistungskategorie: "tk",
+        fachkonzept: "sport_jugend", year: year),
+      unterkunft: 50,
+      uebriges: 8000
+    )
+    # not subventioniert are ignored
+    Event::CourseRecord.create!(
+      event: Fabricate(:aggregate_course, groups: [group], leistungskategorie: "bk",
+        fachkonzept: "sport_jugend", year: year),
+      unterkunft: 500,
+      uebriges: 8000,
+      subventioniert: false
+    )
+  end
+end

--- a/spec/domain/fp2024/cost_accounting/report/indirekte_spenden_spec.rb
+++ b/spec/domain/fp2024/cost_accounting/report/indirekte_spenden_spec.rb
@@ -1,0 +1,38 @@
+#  Copyright (c) 2012-2024, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require "spec_helper"
+
+describe "CostAccounting::Report::IndirekteSpenden" do
+  let(:year) { 2024 }
+  let(:group) { groups(:be) }
+  let(:table) { fp_class("CostAccounting::Table").new(group, year) }
+  let(:report) { table.reports.fetch("indirekte_spenden") }
+
+  before do
+    create_report("indirekte_spenden", aufwand_ertrag_fibu: 50)
+    create_report("raumaufwand", raeumlichkeiten: 100)
+    create_report("honorare", aufwand_ertrag_fibu: 200, verwaltung: 10, beratung: 30)
+  end
+
+  context "abgrenzung_fibu" do
+    it "defaults to nil if total_aufwand.aufwand_ertrag_fibu is zero" do
+      CostAccountingRecord.find_by(report: "honorare")
+        .update_column(:aufwand_ertrag_fibu, nil)
+
+      expect(report.abgrenzung_fibu).to be_nil
+    end
+
+    it "calculates abgrenzung_fibu if total_aufwand.aufwand_ertrag_fibu is nonzero" do
+      expect(report.abgrenzung_fibu).to eq(15)
+    end
+  end
+
+  def create_report(name, values)
+    CostAccountingRecord.create!(values.merge(group_id: group.id,
+      year: year,
+      report: name))
+  end
+end

--- a/spec/domain/fp2024/cost_accounting/report/subtotal_spec.rb
+++ b/spec/domain/fp2024/cost_accounting/report/subtotal_spec.rb
@@ -1,0 +1,54 @@
+#  Copyright (c) 2012-2024, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require "spec_helper"
+
+describe "CostAccounting::Report::Subtotal" do
+  let(:year) { 2024 }
+  let(:group) { groups(:be) }
+  let(:table) { fp_class("CostAccounting::Table").new(group, year) }
+  let(:report) { table.reports.fetch("total_personalaufwand") }
+
+  before do
+    CostAccountingRecord.create!(group_id: group.id,
+      year: year,
+      report: "lohnaufwand",
+      aufwand_ertrag_fibu: 1050,
+      abgrenzung_fibu: 50)
+
+    CostAccountingRecord.create!(group_id: group.id,
+      year: year,
+      report: "sozialversicherungsaufwand",
+      aufwand_ertrag_fibu: 2000)
+
+    TimeRecord::EmployeeTime.create!(group_id: group.id,
+      year: year,
+      verwaltung: 50,
+      mittelbeschaffung: 30,
+      newsletter: 20)
+  end
+
+  context "summed fields" do
+    it "works for fibu" do
+      expect(report.aufwand_ertrag_fibu.to_f).to eq 3050
+    end
+
+    it "works for simple" do
+      expect(report.verwaltung.to_f).to eq 1500
+    end
+  end
+
+  context "#aufwand_ertrag_ko_re" do
+    it "is calculated correctly" do
+      expect(report.aufwand_ertrag_ko_re.to_f).to eq(3000.0)
+    end
+  end
+
+  context "#total" do
+    it "is calculated correctly" do
+      expect(report.total.to_f).to eq(3000.0)
+    end
+  end
+end

--- a/spec/domain/fp2024/cost_accounting/report/time_distributed_spec.rb
+++ b/spec/domain/fp2024/cost_accounting/report/time_distributed_spec.rb
@@ -1,0 +1,112 @@
+#  Copyright (c) 2012-2024, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require "spec_helper"
+
+describe "CostAccounting::Report::TimeDistributed" do
+  let(:year) { 2024 }
+  let(:group) { groups(:be) }
+  let(:table) { fp_class("CostAccounting::Table").new(group, year) }
+  let(:report) { table.reports.fetch("lohnaufwand") }
+
+  context "with cost accounting record" do
+    before do
+      CostAccountingRecord.create!(group_id: group.id,
+        year: year,
+        report: "lohnaufwand",
+        aufwand_ertrag_fibu: 1050,
+        abgrenzung_fibu: 50)
+    end
+
+    context "with time record" do
+      before do
+        TimeRecord::EmployeeTime.create!(
+          group_id: group.id,
+          year: year,
+          verwaltung: 50,
+          mittelbeschaffung: 30,
+          newsletter: 20,
+          nicht_art_74_leistungen: 10,
+          kurse_grundlagen: 40,
+          treffpunkte_grundlagen: 60
+        )
+      end
+
+      context "time fields" do
+        it "works for simple" do
+          expect(report.verwaltung).to eq 250
+          total = (50 + 30 + 20 + 40 + 60)
+          aufwand = 1050 - 50
+          verwaltung = 50
+          expect(report.verwaltung).to eq(aufwand * verwaltung / total)
+        end
+
+        it "works for lufeb" do
+          total = (50 + 30 + 20 + 40 + 60)
+          aufwand = (1050 - 50)
+          lufeb = (0 + 40)
+          expect(report.lufeb).to eq(aufwand * lufeb / total)
+          expect(report.lufeb).to eq 200
+        end
+
+        it "works for treffpunkte" do
+          total = (50 + 30 + 20 + 40 + 60)
+          aufwand = 1050 - 50
+          treffpunkte = (0 + 60)
+          expect(report.treffpunkte).to eq(aufwand * treffpunkte / total)
+          expect(report.treffpunkte).to eq 300
+        end
+      end
+
+      context "#total" do
+        it "is calculated correctly" do
+          expect(report.total).to eq(1000.0)
+        end
+      end
+    end
+
+    context "without time record" do
+      context "time fields" do
+        it "works for simple" do
+          expect(report.verwaltung).to be_nil
+        end
+
+        it "works for lufeb" do
+          expect(report.lufeb).to be_nil
+        end
+      end
+
+      context "#total" do
+        it "is calculated correctly" do
+          expect(report.total).to eq(0.0)
+        end
+      end
+
+      context "#kontrolle" do
+        it "is calculated correctly" do
+          expect(report.kontrolle).to eq(-1000.0)
+        end
+      end
+    end
+  end
+
+  context "without cost accounting record" do
+    context "time fields" do
+      it "works for simple" do
+        expect(report.verwaltung).to be_nil
+      end
+
+      it "works for lufeb" do
+        expect(report.lufeb).to be_nil
+      end
+    end
+
+    context "#total" do
+      it "is calculated correctly" do
+        expect(report.total).to eq(0.0)
+      end
+    end
+  end
+end

--- a/spec/domain/fp2024/cost_accounting/report/total_umlagen_spec.rb
+++ b/spec/domain/fp2024/cost_accounting/report/total_umlagen_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require "spec_helper"
+
+describe Fp2024::CostAccounting::Report::TotalUmlagen do
+  subject { report }
+
+  let(:year) { 2024 }
+  let(:group) { groups(:be) }
+  let(:table) { fp_class("CostAccounting::Table").new(group, year) }
+  let(:report) { table.reports.fetch("total_umlagen") }
+
+  context "gemeinkosten_quota" do
+    context "in a verein with employees" do
+      before do
+        create_employee_time(
+          verwaltung: 50,
+          mittelbeschaffung: 30,
+
+          beratung: 10,
+          treffpunkte: 50,
+          blockkurse: 20,
+          tageskurse: 20,
+
+          nicht_art_74_leistungen: 10
+        )
+
+        create_report("lohnaufwand",
+          aufwand_ertrag_fibu: 10_000,
+          beratung: 1_000,
+          treffpunkte: 5_000,
+          blockkurse: 2_000,
+          tageskurse: 2_000)
+        create_report(
+          "sozialversicherungsaufwand",
+          aufwand_ertrag_fibu: 2000
+        )
+
+        described_class.send :public, :gemeinkosten_quota
+      end
+
+      it "uses personalaufwand" do
+        is_expected.to receive(:total_personalaufwand_for_all_topics)
+          .and_call_original
+
+        subject.treffpunkte
+      end
+
+      it "has the correct quota" do
+        expect(subject.gemeinkosten_quota("treffpunkte"))
+          .to be_within(0.01).of(0.5)
+      end
+    end
+
+    context "in a verein without employees" do
+      before do
+        create_report(
+          "uebriger_sachaufwand",
+          beratung: 700
+        )
+
+        create_course_record(
+          "tp", "treffpunkt",
+          uebriges: 300
+        )
+
+        described_class.send :public, :gemeinkosten_quota
+      end
+
+      it "uses direktkosten" do
+        is_expected.to receive(:total_direktkosten_for_all_topics)
+          .and_call_original
+
+        subject.beratung
+      end
+
+      it "has the correct quota" do
+        expect(subject.gemeinkosten_quota("treffpunkte"))
+          .to be_within(0.01).of(0.3)
+      end
+    end
+  end
+
+  it "sets unused fields to nil" do
+    expect(report.aufwand_ertrag_ko_re).to be_nil
+  end
+
+  private
+
+  def create_report(name, values)
+    CostAccountingRecord.create!(values.merge(group_id: group.id,
+      year: year,
+      report: name))
+  end
+
+  def create_employee_time(values)
+    TimeRecord::EmployeeTime.create!(values.merge(
+      group_id: group.id,
+      year: year
+    ))
+  end
+
+  def create_course_record(lk, fachkonzept, values)
+    Event::CourseRecord.create!(values.merge(
+      event: Fabricate(:course,
+        groups: [group],
+        leistungskategorie: lk, fachkonzept: fachkonzept,
+        dates_attributes: [{start_at: Date.new(year, 10, 1)}]),
+      year: year
+    ))
+  end
+end

--- a/spec/domain/fp2024/cost_accounting/report/unternehmenserfolg_spec.rb
+++ b/spec/domain/fp2024/cost_accounting/report/unternehmenserfolg_spec.rb
@@ -1,0 +1,36 @@
+#  Copyright (c) 2012-2024, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require "spec_helper"
+
+describe "CostAccounting::Report::Unternehmenserfolg" do
+  let(:year) { 2024 }
+  let(:group) { groups(:be) }
+  let(:table) { fp_class("CostAccounting::Table").new(group, year) }
+  let(:report) { table.reports.fetch("unternehmenserfolg") }
+
+  it "sets unused fields to nil" do
+    expect(report.aufwand_ertrag_ko_re).to be_nil
+    expect(report.kontrolle).to be_nil
+  end
+
+  it "calculates the profit" do
+    create_report("leistungsertrag", aufwand_ertrag_fibu: 100)
+    create_report("raumaufwand", aufwand_ertrag_fibu: 20)
+    expect(report.total).to eq(80)
+  end
+
+  it "calculates the loss" do
+    create_report("leistungsertrag", aufwand_ertrag_fibu: 100)
+    create_report("raumaufwand", aufwand_ertrag_fibu: 120)
+    expect(report.total).to eq(-20)
+  end
+
+  def create_report(name, values)
+    CostAccountingRecord.create!(values.merge(group_id: group.id,
+      year: year,
+      report: name))
+  end
+end

--- a/spec/domain/fp2024/cost_accounting/table_spec.rb
+++ b/spec/domain/fp2024/cost_accounting/table_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2024, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require "spec_helper"
+
+describe "CostAccounting::Table" do
+  let(:year) { 2016 }
+  let(:group) { groups(:be) }
+  let(:table) { fp_class("CostAccounting::Table").new(group, year) }
+
+  context "#value_of" do
+    it "is initialized without records" do
+      errors = []
+      fp_class("CostAccounting::Table")::REPORTS.each do |report|
+        fp_class("CostAccounting::Report::Base::FIELDS").each do |field|
+          value = table.value_of(report.key, field).to_d
+          if value != 0.0
+            errors << "#{report.key}-#{field} is expected to be 0, got #{value}"
+          end
+        end
+      end
+
+      expect(errors).to be_blank, errors.join("\n")
+    end
+  end
+end

--- a/spec/domain/fp2024/course_reporting/aggregation_spec.rb
+++ b/spec/domain/fp2024/course_reporting/aggregation_spec.rb
@@ -1,0 +1,421 @@
+#  Copyright (c) 2024-2021, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require "spec_helper"
+
+describe Fp2024::CourseReporting::Aggregation do
+  include Featureperioden::Domain
+
+  let(:year) { 2024 }
+  let(:values) do
+    {
+      kursdauer: 0.5,
+      challenged_canton_count_attributes: {be: 1, zh: 2},
+      affiliated_canton_count_attributes: {be: 2},
+      teilnehmende_weitere: 4,
+      absenzen_behinderte: 0.5,
+      absenzen_angehoerige: 0,
+      absenzen_weitere: nil,
+      leiterinnen: 1,
+      fachpersonen: 2,
+      hilfspersonal_ohne_honorar: 3,
+      hilfspersonal_mit_honorar: 4,
+      kuechenpersonal: 5,
+      honorare_inkl_sozialversicherung: 10,
+      unterkunft: 20,
+      uebriges: 30,
+      beitraege_teilnehmende: 10,
+      spezielle_unterkunft: true,
+      gemeinkostenanteil: 10
+    }
+  end
+
+  let(:aggregation) { new_aggregation }
+
+  before { Event::CourseRecord.destroy_all }
+
+  context "#scope" do
+    before { create!(create_course) }
+
+    it "returns records grouped by kursart and kursfachkonzept" do
+      expect(aggregation.scope.count).to eq({["freizeit_und_sport", "sport_jugend"] => 1})
+    end
+
+    it "filters based on leistungskategorie" do
+      aggregation = new_aggregation(leistungskategorie: :sk)
+      expect(aggregation.scope.count).to be_empty
+    end
+
+    it "filters based on group" do
+      aggregation = new_aggregation(group_id: groups(:dachverein).id)
+      expect(aggregation.scope.count).to be_empty
+    end
+
+    it "filters based on year" do
+      aggregation = new_aggregation(year: 2012)
+      expect(aggregation.scope.count).to be_empty
+    end
+
+    it "does not filter based on zugeteilte_kategorie anymore" do # see Fp2015, if you need this
+      aggregation = new_aggregation(zugeteilte_kategorie: [2])
+      expect(aggregation.scope.count).to_not be_empty
+    end
+
+    it "filters based on subventioniert" do
+      aggregation = new_aggregation(subventioniert: false)
+      expect(aggregation.scope.count).to be_empty
+    end
+  end
+
+  context "structure and counting courses" do
+    let(:kursfachkonzepte) { %w[freizeit_jugend autonomie_foerderung] }
+
+    %w[bk tk].each do |leistungskategorie|
+      context leistungskategorie do
+        let(:aggregation) { new_aggregation(leistungskategorie: leistungskategorie) }
+
+        it "sums by inputkritierien" do
+          kursfachkonzepte.each do |k|
+            create!(create_course(leistungskategorie, [groups(:be)], 2024, k), :freizeit_und_sport)
+          end
+
+          expect(course_totals(:anzahl_kurse, "freizeit_jugend")).to eq(1)
+          expect(course_totals(:anzahl_kurse, "freizeit_erwachsen")).to eq(0)
+          expect(course_totals(:anzahl_kurse, "sport_jugend")).to eq(0)
+          expect(course_totals(:anzahl_kurse, "sport_erwachsen")).to eq(0)
+          expect(course_totals(:anzahl_kurse, "autonomie_foerderung")).to eq(1)
+        end
+      end
+    end
+
+    context "sk" do
+      let(:aggregation) { new_aggregation(leistungskategorie: "sk") }
+
+      it "sums once for all kursfachkonzepte" do
+        kursfachkonzepte.each do |k|
+          create!(create_course("sk", [groups(:be)], 2024, k), "freizeit_und_sport")
+        end
+
+        expect(course_totals(:anzahl_kurse)).to eq(2)
+      end
+    end
+  end
+
+  context "summed and aggregated values" do
+    it "builds total for three 'freizeit_und_sport' records" do
+      3.times { create!(create_course, "freizeit_und_sport", values) }
+
+      assert_summed_totals
+
+      expect_values(:anzahl_kurse, 3)
+      expect_values(:kursdauer, 1.5)
+
+      expect_values(:teilnehmende, 27)
+      expect_values(:teilnehmende_behinderte, 9)
+      expect_values(:teilnehmende_angehoerige, 6)
+      expect_values(:teilnehmende_weitere, 12)
+
+      expect_values(:total_tage_teilnehmende, 12)
+      expect_values(:tage_behinderte, 3)
+      expect_values(:tage_angehoerige, 3)
+      expect_values(:tage_weitere, 6)
+
+      expect_values(:total_absenzen, 1.5)
+      expect_values(:absenzen_behinderte, 1.5)
+      expect_values(:absenzen_angehoerige, 0)
+      expect_values(:absenzen_weitere, 0)
+
+      expect_values(:betreuende, 30)
+      expect_values(:leiterinnen, 3)
+      expect_values(:fachpersonen, 6)
+      expect_values(:betreuerinnen, 0)
+      expect_values(:hilfspersonal_ohne_honorar, 9)
+      expect_values(:hilfspersonal_mit_honorar, 12)
+
+      expect_values(:kuechenpersonal, 15)
+
+      expect_values(:direkter_aufwand, 180)
+      expect_values(:honorare_inkl_sozialversicherung, 30)
+      expect_values(:unterkunft, 60)
+      expect_values(:uebriges, 90)
+
+      dk_pro_le = BigDecimal(180) / BigDecimal(12) # direkter_aufwand / total_tage_teilnehmende
+      vk_pro_le = BigDecimal(210) / BigDecimal(12) # total_vollkosten / total_tage_teilnehmende
+
+      expect_values(:direkte_kosten_pro_le, dk_pro_le)
+      expect_values(:total_vollkosten, 210)
+      expect_values(:vollkosten_pro_le, vk_pro_le)
+      expect_values(:direkter_aufwand, 180)
+
+      expect_values(:beitraege_teilnehmende, 30)
+      expect_values(:gemeinkostenanteil, 30)
+      expect_values(:betreuungsschluessel, 9 / 30.0)
+
+      expect_values(:anzahl_spezielle_unterkunft, 3)
+    end
+
+    it "builds total for two 'freizeit_und_sport' and two 'weiterbildung' records" do
+      2.times { create!(create_course, "freizeit_und_sport", values) }
+      2.times { create!(create_course, "weiterbildung", values) }
+
+      assert_summed_totals
+
+      expect_values(:anzahl_kurse, 4)
+      expect_values(:kursdauer, 2)
+
+      expect_values(:teilnehmende, 36)
+      expect_values(:teilnehmende_behinderte, 12)
+      expect_values(:teilnehmende_angehoerige, 8)
+      expect_values(:teilnehmende_weitere, 16)
+
+      expect_values(:total_tage_teilnehmende, 16)
+      expect_values(:tage_behinderte, 4)
+      expect_values(:tage_angehoerige, 4)
+      expect_values(:tage_weitere, 8)
+
+      expect_values(:total_absenzen, 2)
+      expect_values(:absenzen_behinderte, 2)
+      expect_values(:absenzen_angehoerige, 0)
+      expect_values(:absenzen_weitere, 0)
+
+      expect_values(:betreuende, 40)
+      expect_values(:leiterinnen, 4)
+      expect_values(:fachpersonen, 8)
+      expect_values(:betreuerinnen, 0)
+      expect_values(:hilfspersonal_ohne_honorar, 12)
+      expect_values(:hilfspersonal_mit_honorar, 16)
+      expect_values(:kuechenpersonal, 20)
+
+      expect_values(:direkter_aufwand, 240)
+      expect_values(:honorare_inkl_sozialversicherung, 40)
+      expect_values(:unterkunft, 80)
+      expect_values(:uebriges, 120)
+
+      dk_pro_le = BigDecimal(240) / 16 # direkter_aufwand / total_tage_teilnehmende
+      vk_pro_le = BigDecimal(280) / 16 # total_vollkosten / total_tage_teilnehmende
+
+      expect_values(:direkte_kosten_pro_le, dk_pro_le)
+      expect_values(:vollkosten_pro_le, vk_pro_le)
+      expect_values(:direkter_aufwand, 240)
+
+      expect_values(:beitraege_teilnehmende, 40)
+      expect_values(:gemeinkostenanteil, 40)
+      expect_values(:betreuungsschluessel, 12 / 40.0)
+
+      expect_values(:anzahl_spezielle_unterkunft, 4)
+    end
+
+    it "sums 'spezielle_unterkunft' correctly" do
+      create!(create_course, "freizeit_und_sport", values.merge(spezielle_unterkunft: false))
+      create!(create_course, "weiterbildung", values.merge(spezielle_unterkunft: true))
+      expect_values(:anzahl_spezielle_unterkunft, 1)
+    end
+  end
+
+  context "over all groups" do
+    let(:aggregation) { new_aggregation(group_id: nil) }
+
+    it "sums the individual group aggregations" do
+      2.times { create!(create_course, "freizeit_und_sport", values) }
+      2.times { create!(create_course, "weiterbildung", values) }
+      2.times { create!(create_course("bk", [groups(:fr)]), "weiterbildung", values) }
+
+      assert_summed_totals
+
+      aggregation_be_1 = new_aggregation
+      aggregation_fr_1 = new_aggregation(group_id: groups(:fr).id)
+      aggregation_be_123 = new_aggregation(zugeteilte_kategorie: [1, 2, 3])
+      aggregation_fr_123 = new_aggregation(group_id: groups(:fr).id,
+        zugeteilte_kategorie: [1, 2, 3])
+      aggregation_123 = new_aggregation(group_id: nil, zugeteilte_kategorie: [1, 2, 3])
+
+      [
+        :anzahl_kurse,
+        :kursdauer,
+
+        :teilnehmende,
+        :teilnehmende_behinderte,
+        :teilnehmende_angehoerige,
+        :teilnehmende_weitere,
+
+        :total_absenzen,
+        :absenzen_behinderte,
+        :absenzen_angehoerige,
+        :absenzen_weitere,
+
+        :total_tage_teilnehmende,
+        :tage_behinderte,
+        :tage_angehoerige,
+        :tage_weitere,
+
+        :total_absenzen,
+        :absenzen_behinderte,
+        :absenzen_angehoerige,
+        :absenzen_weitere,
+
+        :betreuende,
+        :leiterinnen,
+        :fachpersonen,
+        :hilfspersonal_ohne_honorar,
+        :hilfspersonal_mit_honorar,
+        :kuechenpersonal,
+
+        :direkter_aufwand,
+        :honorare_inkl_sozialversicherung,
+        :unterkunft,
+        :uebriges,
+
+        :direkter_aufwand,
+
+        :beitraege_teilnehmende,
+        :gemeinkostenanteil,
+        :anzahl_spezielle_unterkunft
+      ].each do |attr|
+        assert_summed(attr, :total, :all, aggregation, aggregation_be_1, aggregation_fr_1)
+        assert_summed(attr, :total, :sport_jugend, aggregation, aggregation_be_1, aggregation_fr_1)
+
+        assert_summed(attr, :total, :all, aggregation_123, aggregation_be_123, aggregation_fr_123)
+        assert_summed(attr, :total, :sport_jugend, aggregation_123, aggregation_be_123,
+          aggregation_fr_123)
+      end
+
+      dk_pro_le = BigDecimal(360) / 24 # direkter_aufwand / total_tage_teilnehmende
+      vk_pro_le = BigDecimal(420) / 24 # total_vollkosten / total_tage_teilnehmende
+
+      expect_values(:direkte_kosten_pro_le, dk_pro_le)
+      expect_values(:vollkosten_pro_le, vk_pro_le)
+      expect_values(:betreuungsschluessel, 18 / 60.0)
+    end
+
+    def assert_summed(attr, kursart, kursfachkonzept, overall, *aggregations)
+      sum = aggregations.sum { |a| a.course_counts(kursfachkonzept.to_s, kursart.to_s, attr).to_d }
+      actual = overall.course_counts(kursfachkonzept.to_s, kursart.to_s, attr).to_d
+      expect(actual).to eq(sum)
+    end
+  end
+
+  context "treffpunkt-aggregation" do
+    let(:cr_defaults) do
+      {
+        subventioniert: true,
+        year: year
+      }
+    end
+
+    let!(:treffpunkt_a_course_record) do
+      # rubocop:todo Layout/LineLength
+      create!(create_course("tp", [groups(:fr)], 2024, "treffpunkt"), "weiterbildung", cr_defaults.merge({
+        # rubocop:enable Layout/LineLength
+        challenged_canton_count_attributes: {be: 10},
+        affiliated_canton_count_attributes: {be: 2},
+
+        kursdauer: 0.1e2,
+        anzahl_kurse: 1,
+        tage_behinderte: 0.1e3,
+        tage_angehoerige: 0.0,
+        tage_weitere: 0.0,
+        betreuerinnen: 2
+      }))
+    end
+
+    let!(:treffpunkt_b_course_record) do
+      # rubocop:todo Layout/LineLength
+      create!(create_course("tp", [groups(:fr)], 2024, "treffpunkt"), "weiterbildung", cr_defaults.merge({
+        # rubocop:enable Layout/LineLength
+        challenged_canton_count_attributes: {be: 5},
+        affiliated_canton_count_attributes: {be: 1},
+
+        kursdauer: 0.2e1,
+        anzahl_kurse: 1,
+        tage_behinderte: 0.1e2,
+        tage_angehoerige: 0.0,
+        tage_weitere: 0.0,
+        betreuerinnen: 1
+      }))
+    end
+
+    subject(:tp_agg) do
+      described_class
+        .new(groups(:fr).id, cr_defaults[:year], "tp", :unused, cr_defaults[:subventioniert])
+        .course_counts("all", "total", :itself)
+    end
+
+    it "has assumptions" do
+      expect(tp_agg).to be_a Event::CourseRecord
+      expect(tp_agg).to be_aggregation_record
+
+      expect(treffpunkt_a_course_record.teilnehmende_behinderte).to eq 10
+      expect(treffpunkt_b_course_record.teilnehmende_behinderte).to eq 5
+      expect(treffpunkt_a_course_record.teilnehmende_angehoerige).to eq 2
+
+      expect(treffpunkt_a_course_record.betreuerinnen).to eq 2
+      expect(treffpunkt_a_course_record.kursdauer).to eq 10
+      expect(treffpunkt_a_course_record.betreuungsstunden).to eq(2 * 10) # 20
+
+      expect(treffpunkt_b_course_record.betreuerinnen).to eq 1
+      expect(treffpunkt_b_course_record.kursdauer).to eq 2
+      expect(treffpunkt_b_course_record.betreuungsstunden).to eq(1 * 2) # 2
+    end
+
+    it "sums products and caluclated values correctly" do
+      expect(tp_agg.anzahl_kurse).to eq 2
+      expect(tp_agg.kursdauer).to eq 12
+      expect(tp_agg.betreuungsstunden).to eq 22 # 20 + 2 -> see assumptions
+      expect(tp_agg.total_stunden_betreuung).to eq 22 # same as betreuungsstunden (now)
+      expect(tp_agg.betreuende).to eq 3
+    end
+
+    it "calculate the teilnehmer correctly" do
+      expect(tp_agg.teilnehmende_behinderte).to eq 15 # 10 + 5 -> see assumptions
+      expect(tp_agg.teilnehmende_angehoerige).to eq 3
+      expect(tp_agg.teilnehmende_weitere).to eq 0
+      expect(tp_agg.teilnehmende).to eq 18
+    end
+  end
+
+  def assert_summed_totals
+    records = Event::CourseRecord.all.to_a
+    attrs = fp_class("CourseReporting::Aggregation")::RUBY_SUMMED_ATTRS
+    attrs.each do |attr|
+      expected = records.sum { |r| r.send(attr).to_d }
+      actual = course_totals(attr)
+      expect(actual).to eq(expected), "expected #{attr} to equal #{expected}, got #{actual}"
+    end
+  end
+
+  def course_counts(attr, kursart = :freizeit_und_sport, kursfachkonzept = :sport_jugend)
+    aggregation.course_counts(kursfachkonzept.to_s, kursart.to_s, attr)
+  end
+
+  def course_totals(attr, kursfachkonzept = :all)
+    course_counts(attr, :total, kursfachkonzept)
+  end
+
+  def expect_values(attr, total)
+    expect(course_totals(attr)).to eq(total),
+      "expected #{attr} to equal #{total}, got #{course_totals(attr)}"
+  end
+
+  def new_aggregation(attrs = {})
+    defaults = {group_id: groups(:be).id,
+                year: 2024,
+                leistungskategorie: "bk",
+                zugeteilte_kategorie: [1],
+                subventioniert: true}
+    described_class.new(*defaults.merge(attrs).values)
+  end
+
+  def create_course(leistungskategorie = "bk", group_list = [groups(:be)], year = 2024,
+    fachkonzept = "sport_jugend")
+    Event::Course.create!(groups: group_list,
+      name: "test",
+      leistungskategorie: leistungskategorie, fachkonzept: fachkonzept,
+      dates_attributes: [{start_at: DateTime.new(year, 0o4, 15, 12, 0o0)}])
+  end
+
+  def create!(event, kursart = "freizeit_und_sport", attrs = {})
+    Event::CourseRecord.create!(attrs.merge(event: event, kursart: kursart.to_s))
+  end
+end

--- a/spec/domain/fp2024/course_reporting/client_statistics_spec.rb
+++ b/spec/domain/fp2024/course_reporting/client_statistics_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024-2021, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require "spec_helper"
+
+describe Fp2024::CourseReporting::ClientStatistics do
+  let(:year) { 2024 }
+  let(:stats) { described_class.new(year) }
+
+  before do
+    create_course(year, :be, "bk",
+      {be: 1, ag: 2, zh: 3, another: 4},
+      {be: 0, ag: 1, zh: 1, another: 2})
+
+    create_course(year, :be, "bk",
+      {be: 2, ag: 4, zh: 6, another: 8},
+      {be: 1, ag: 2, zh: 3, another: 4},
+      true,
+      :aggregate_course)
+
+    create_course(year, :fr, "bk",
+      {be: 3, ag: 3, zh: 3, tg: 3, another: 3})
+
+    create_course(year, :fr, "tk",
+      {be: 1, ag: 1, another: 1})
+
+    create_course(year, :fr, "tk",
+      {be: 1, zh: 1, another: 1})
+
+    # other year
+    create_course(year - 1, :fr, "bk",
+      {be: 4, ag: 4, zh: 4, tg: 4, another: 4},
+      {be: 2, ag: 2, zh: 2, another: 2})
+
+    # same year, non subventioniert
+    create_course(year, :be, "bk",
+      {be: 1, ag: 2, zh: 3, another: 4},
+      {be: 0, ag: 1, zh: 1, another: 2},
+      false)
+  end
+
+  it "has a list of groups" do
+    expect(stats.groups).to be_an Array
+    expect(stats.groups.map(&:class).map(&:name).uniq).to eql ["Group::Dachverein",
+      "Group::Regionalverein"]
+    expect(stats.groups.map(&:name)).to eql [
+      "insieme Schweiz",
+      "Kanton Bern",
+      "Biel-Seeland",
+      "Freiburg"
+    ]
+  end
+
+  it "knowns the cantons" do
+    expect(stats.cantons).to eql %w[
+      ag ai ar be bl bs fr ge gl gr ju lu ne
+      nw ow sg sh so sz tg ti ur vd vs zg zh
+      another
+    ]
+  end
+
+  it "can load summed values" do
+    expect(stats.send(:raw_group_canton_participants).size).to eq(3)
+    rows = stats.send(:raw_group_canton_participants)
+    gcps = rows.map do |row|
+      Fp2024::CourseReporting::ClientStatistics::GroupCantonParticipant.new(*row)
+    end
+
+    expect(gcps.size).to eq(3)
+
+    results = gcps.each_with_object({}) do |gcp, memo|
+      memo[gcp.group_id] ||= {}
+      memo[gcp.group_id][gcp.leistungskategorie] = gcp
+    end
+
+    expect(results).to be_a Hash
+    expect(results.keys).to match_array [groups(:be).id, groups(:fr).id]
+
+    expect(stats.send(:group_canton_participants).keys).to match_array [groups(:be).id,
+      groups(:fr).id]
+  end
+
+  it "contains summed values per group" do
+    # new style
+    bern_bk = stats.group_participants(groups(:be).id, "bk", "sport")
+    expect(bern_bk.be).to eq(4)
+    expect(bern_bk.ag).to eq(9)
+    expect(bern_bk.zh).to eq(13)
+    expect(bern_bk.tg).to eq(0)
+    expect(bern_bk.another).to eq(18)
+
+    # old style, still supported
+    expect(stats.group_canton_count(groups(:fr).id, :be, "bk", "sport")).to eq(3)
+    expect(stats.group_canton_count(groups(:fr).id, :ag, "bk", "sport")).to eq(3)
+    expect(stats.group_canton_count(groups(:fr).id, :zh, "bk", "sport")).to eq(3)
+    expect(stats.group_canton_count(groups(:fr).id, :tg, "bk", "sport")).to eq(3)
+    expect(stats.group_canton_count(groups(:fr).id, :another, "bk", "sport")).to eq(3)
+
+    expect(stats.group_canton_count(groups(:fr).id, :be, "tk", "sport")).to eq(2)
+    expect(stats.group_canton_count(groups(:fr).id, :ag, "tk", "sport")).to eq(1)
+    expect(stats.group_canton_count(groups(:fr).id, :zh, "tk", "sport")).to eq(1)
+    expect(stats.group_canton_count(groups(:fr).id, :tg, "tk", "sport")).to eq(0)
+    expect(stats.group_canton_count(groups(:fr).id, :another, "tk", "sport")).to eq(2)
+
+    expect(stats.group_canton_count(groups(:be).id, :be, "sk", "sport")).to eq(0)
+    expect(stats.group_canton_count(groups(:be).id, :another, "sk", "sport")).to eq(0)
+    expect(stats.group_canton_count(groups(:fr).id, :be, "sk", "sport")).to eq(0)
+    expect(stats.group_canton_count(groups(:fr).id, :another, "sk", "sport")).to eq(0)
+  end
+
+  private
+
+  # rubocop:todo Metrics/MethodLength
+  # rubocop:todo Metrics/AbcSize
+  def create_course(year, group, leistungskategorie, challenged = {}, affiliated = {},
+    subventioniert = true, event_type = :course)
+    event = nil
+    if event_type == :aggregate_course
+      event = Fabricate(event_type,
+        leistungskategorie: leistungskategorie,
+        fachkonzept: "sport_jugend",
+        year: year)
+      event.update!(group_ids: [groups(group).id])
+    else
+      event = Fabricate(event_type,
+        leistungskategorie: leistungskategorie,
+        fachkonzept: "sport_jugend")
+      event.update!(group_ids: [groups(group).id])
+      event.dates.create!(start_at: Time.zone.local(year, 0o5, 11))
+    end
+    r = Event::CourseRecord.create!(
+      event_id: event.id, year: year, subventioniert: subventioniert
+    )
+    r.create_challenged_canton_count!(challenged) if challenged.present?
+    r.create_affiliated_canton_count!(affiliated) if affiliated.present?
+    r.update!(teilnehmende_mehrfachbehinderte: challenged.values.sum / 3)
+  end
+  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/MethodLength
+end

--- a/spec/domain/fp2024/export/tabular/course_reporting/aggregation_spec.rb
+++ b/spec/domain/fp2024/export/tabular/course_reporting/aggregation_spec.rb
@@ -1,0 +1,237 @@
+#  Copyright (c) 2024-2021, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require "spec_helper"
+
+describe Fp2024::Export::Tabular::CourseReporting::Aggregation do
+  let(:values) do
+    {
+      kursdauer: 2,
+      challenged_canton_count_attributes: {be: 1},
+      affiliated_canton_count_attributes: {be: 2},
+      teilnehmende_weitere: nil,
+      absenzen_behinderte: 0.5,
+      absenzen_angehoerige: 1,
+      absenzen_weitere: nil,
+      leiterinnen: 1,
+      betreuerinnen: 10,
+      fachpersonen: 2,
+      hilfspersonal_ohne_honorar: 3,
+      hilfspersonal_mit_honorar: 4,
+      kuechenpersonal: 5,
+      honorare_inkl_sozialversicherung: 10,
+      unterkunft: 20,
+      uebriges: 30,
+      beitraege_teilnehmende: 10,
+      spezielle_unterkunft: true,
+      gemeinkostenanteil: 10
+    }
+  end
+
+  let(:year) { 2024 }
+
+  def export(leistungskategorie)
+    exporter(leistungskategorie).data_rows.to_a
+  end
+
+  def exporter(leistungskategorie)
+    described_class.new(new_aggregration(leistungskategorie: leistungskategorie))
+  end
+
+  %w[bk tk].each do |leistungskategorie|
+    context leistungskategorie do
+      before do
+        create!(create_course(leistungskategorie, fachkonzept: "sport_jugend"),
+          "freizeit_und_sport", values)
+        create!(create_course(leistungskategorie, fachkonzept: "sport_erwachsen"),
+          "freizeit_und_sport", values)
+        create!(create_course(leistungskategorie, fachkonzept: "freizeit_jugend"),
+          "freizeit_und_sport", values)
+        create!(create_course(leistungskategorie, fachkonzept: "freizeit_erwachsen"),
+          "freizeit_und_sport", values)
+        create!(create_course(leistungskategorie, fachkonzept: "autonomie_foerderung"),
+          "weiterbildung", values)
+      end
+
+      it "contains correct headers" do
+        expect(exporter(leistungskategorie).labels).to eq [
+          "",
+          "Freizeit Kinder & Jugendliche",
+          "Freizeit Erwachsene & altersdurchmischt",
+          "Sport Kinder & Jugendliche",
+          "Sport Erwachsene & altersdurchmischt",
+          "Förderung der Autonomie/Bildung",
+          "Total"
+        ]
+      end
+
+      it "contains correct row headers, values and sums" do
+        rows = [nil] + export(leistungskategorie)
+        expect(rows[1]).to eq ["Anzahl Kurse", 1, 1, 1, 1, 1, 5]
+        expect(rows[2]).to eq ["Anzahl Kurstage", 2.0, 2.0, 2.0, 2.0, 2.0, 10.0]
+        expect(rows[3]).to eq ["Anzahl effektive TeilnehmerInnen", 3, 3, 3, 3, 3, 15]
+        expect(rows[4]).to eq ["davon Personen mit Behinderung", 1, 1, 1, 1, 1, 5]
+        expect(rows[5]).to eq ["davon Angehörige", 2, 2, 2, 2, 2, 10]
+        expect(rows[6]).to eq ["davon nicht Bezugsberechtigte", 0, 0, 0, 0, 0, 0]
+        expect(rows[7]).to eq ["Absenztage", 1.5, 1.5, 1.5, 1.5, 1.5, 7.5]
+        expect(rows[8]).to eq ["davon Absenztage Personen mit Behinderung", 0.5, 0.5, 0.5, 0.5,
+          0.5, 2.5]
+        expect(rows[9]).to eq ["davon Absenztage Angehörige", 1.0, 1.0, 1.0, 1.0, 1.0, 5.0]
+        expect(rows[10]).to eq ["davon Absenztage nicht Bezugsberechtigte", 0, 0, 0, 0.0, 0.0, 0.0]
+        expect(rows[11]).to eq ["Effektive TeilnehmerInnentage", 4.5, 4.5, 4.5, 4.5, 4.5, 22.5]
+        expect(rows[12]).to eq ["davon TeilnehmerInnentage Personen mit Behinderung", 1.5, 1.5,
+          1.5, 1.5, 1.5, 7.5]
+        expect(rows[13]).to eq ["davon TeilnehmerInnentage Angehörige", 3.0, 3.0, 3.0, 3.0, 3.0,
+          15.0]
+        expect(rows[14]).to eq ["davon TeilnehmerInnentage nicht Bezugsberechtigte", 0.0, 0.0, 0.0,
+          0.0, 0.0, 0.0]
+        expect(rows[15]).to eq ["Anzahl Betreuungspersonal", 10, 10, 10, 10, 10, 50]
+        expect(rows[16]).to eq ["davon LeiterInnen", 1, 1, 1, 1, 1, 5]
+        expect(rows[17]).to eq ["davon Fachpersonen hochqualifiziert", 2, 2, 2, 2, 2, 10]
+        expect(rows[18]).to eq ["davon Hilfspersonal ohne Honorar", 3, 3, 3, 3, 3, 15]
+        expect(rows[19]).to eq ["davon Hilfspersonal mit Honorar", 4, 4, 4, 4, 4, 20]
+        expect(rows[20]).to eq ["Anzahl Küchenpersonal", 5, 5, 5, 5, 5, 25]
+        expect(rows[21]).to eq ["Gesamtaufwand direkte Kosten", 60.0, 60.0, 60.0, 60.0, 60.0, 300.0]
+        expect(rows[22]).to eq ["davon Honorare", 10.0, 10.0, 10.0, 10.0, 10.0, 50.0]
+        expect(rows[23]).to eq ["davon Unterkunft/Raumaufwand", 20.0, 20.0, 20.0, 20.0, 20.0, 100.0]
+        expect(rows[24]).to eq ["davon übriger Aufwand inkl. Verpflegung", 30.0, 30.0, 30.0, 30.0,
+          30.0, 150.0]
+
+        expect(rows[25][0]).to eq "Durchschnittliche direkte Kosten pro TeilnehmerInnentag"
+        expect(rows[25][1..].collect(&:to_i)).to eq [13, 13, 13, 13, 13, 13]
+        expect(rows[26]).to eq ["Vollkosten", 70.0, 70.0, 70.0, 70.0, 70.0, 350.0]
+        expect(rows[27][0]).to eq "Durchschnittliche Vollkosten pro TeilnehmerInnentag"
+        expect(rows[27][1..].collect(&:to_i)).to eq [15, 15, 15, 15, 15, 15]
+        expect(rows[28]).to eq ["Beiträge Teilnehmende", 10.0, 10.0, 10.0, 10.0, 10.0, 50.0]
+        expect(rows[29]).to eq ["Betreuungschlüssel (Teilnehmende / Betreuende)", 0.1, 0.1, 0.1,
+          0.1, 0.1, 0.1]
+        expect(rows[30]).to eq ["Anzahl Kurse mit spezieller Unterkunft", 1, 1, 1, 1, 1, 5]
+      end
+    end
+  end
+
+  context "sk" do
+    before do
+      2.times do
+        values[:absenzen_behinderte] = 2 # sk allows only integers
+        create!(create_course("sk", fachkonzept: "freizeit_jugend"), "freizeit_und_sport", values)
+        create!(create_course("sk", fachkonzept: "autonomie_foerderung"), "weiterbildung", values)
+      end
+    end
+
+    it "contains correct headers" do
+      expect(exporter("sk").labels).to eq [
+        "",
+        "Freizeit Kinder & Jugendliche",
+        "Freizeit Erwachsene & altersdurchmischt",
+        "Sport Kinder & Jugendliche",
+        "Sport Erwachsene & altersdurchmischt",
+        "Förderung der Autonomie/Bildung",
+        "Total"
+      ]
+    end
+
+    it "contains correct row headers, values and sums" do
+      rows = [nil] + export("sk")
+      expect(rows[1]).to eq ["Anzahl Kurse", 2, 0, 0, 0, 2, 4]
+      expect(rows[2]).to eq ["Anzahl Kursstunden", BigDecimal("4.0"), BigDecimal("0.0"),
+        BigDecimal("0.0"), BigDecimal("0.0"), BigDecimal("4.0"), BigDecimal("8.0")]
+      expect(rows[3]).to eq ["Anzahl effektive TeilnehmerInnen", 6, 0, 0, 0, 6, 12]
+      expect(rows[4]).to eq ["davon Personen mit Behinderung", 2, 0, 0, 0, 2, 4]
+      expect(rows[5]).to eq ["davon Angehörige", 4, 0, 0, 0, 4, 8]
+      expect(rows[6]).to eq ["davon nicht Bezugsberechtigte", 0, 0, 0, 0, 0, 0]
+      expect(rows[7]).to eq ["Absenzstunden", 6.00, 0.00, 0.00, 0.00, 6.00, 12.00]
+      expect(rows[8]).to eq ["davon Absenzstunden Personen mit Behinderung", 4.00, 0.00, 0.00,
+        0.00, 4.00, 8.00]
+      expect(rows[9]).to eq ["davon Absenzstunden Angehörige", 2.00, 0.00, 0.00, 0.00, 2.00, 4.00]
+      expect(rows[10]).to eq ["davon Absenzstunden nicht Bezugsberechtigte", 0.00, 0.00, 0.00,
+        0.00, 0.00, 0.00]
+      expect(rows[11]).to eq ["Effektive TeilnehmerInnenstunden", 6.0, 0.0, 0.0, 0.0, 6.0, 12.00]
+      expect(rows[12]).to eq ["davon TeilnehmerInnenstunden Personen mit Behinderung", 0.0, 0.0,
+        0.0, 0.0, 0.0, 0.00]
+      expect(rows[13]).to eq ["davon TeilnehmerInnenstunden Angehörige", 6.00, 0.00, 0.00, 0.00,
+        6.00, 12.00]
+      expect(rows[14]).to eq ["davon TeilnehmerInnenstunden nicht Bezugsberechtigte", 0.00, 0.00,
+        0.00, 0.00, 0.00, 0.00]
+      expect(rows[15]).to eq ["Anzahl Betreuungspersonal", 20, 0, 0, 0, 20, 40]
+      expect(rows[16]).to eq ["davon LeiterInnen", 2, 0, 0, 0, 2, 4]
+      expect(rows[17]).to eq ["davon Fachpersonen hochqualifiziert", 4, 0, 0, 0, 4, 8]
+      expect(rows[18]).to eq ["davon Hilfspersonal ohne Honorar", 6, 0, 0, 0, 6, 12]
+      expect(rows[19]).to eq ["davon Hilfspersonal mit Honorar", 8, 0, 0, 0, 8, 16]
+      expect(rows[20]).to eq ["Anzahl Küchenpersonal", 10, 0, 0, 0, 10, 20]
+      expect(rows[21]).to eq ["Gesamtaufwand direkte Kosten", 120.00, 0.00, 0.00, 0.00, 120.00,
+        240.00]
+      expect(rows[22]).to eq ["davon Honorare", 20.00, 0.00, 0.00, 0.00, 20.00, 40.00]
+      expect(rows[23]).to eq ["davon Unterkunft/Raumaufwand", 40.00, 0.00, 0.00, 0.00, 40.00, 80.00]
+      expect(rows[24]).to eq ["davon übriger Aufwand inkl. Verpflegung", 60.00, 0.00, 0.00, 0.00,
+        60.00, 120.00]
+      expect(rows[25][0]).to eq "Durchschnittliche direkte Kosten pro TeilnehmerInnenstunde"
+      expect(rows[25][1..].collect(&:to_i)).to eq [nil, 20, 0, 0, 0, 20, 20][1..]
+      expect(rows[26]).to eq ["Vollkosten", 140.00, 0.00, 0.00, 0.00, 140.00, 280.00]
+      expect(rows[27][0]).to eq "Durchschnittliche Vollkosten pro TeilnehmerInnenstunde"
+      expect(rows[27][1..].collect(&:to_i)).to eq [nil, 23, 0, 0, 0, 23, 23][1..]
+      expect(rows[28]).to eq ["Beiträge Teilnehmende", 20.00, 0.00, 0.00, 0.00, 20.00, 40.00]
+      expect(rows[29]).to eq ["Betreuungschlüssel (Teilnehmende / Betreuende)", 0.10, 0.00, 0.00,
+        0.00, 0.10, 0.10]
+      expect(rows[30]).to eq ["Anzahl Kurse mit spezieller Unterkunft", 0, 0, 0, 0, 0, 0]
+    end
+  end
+
+  context "tp" do
+    before do
+      2.times do
+        values[:absenzen_behinderte] = 2
+        create!(create_course("tp", fachkonzept: "treffpunkt"), "freizeit_und_sport", values)
+        create!(create_course("tp", fachkonzept: "treffpunkt"), "weiterbildung", values)
+      end
+    end
+
+    it "contains correct headers" do
+      expect(exporter("tp").labels).to eq ["", "Total"]
+    end
+
+    it "contains correct row headers, values and sums" do
+      rows = [nil] + export("tp")
+      expect(rows[1]).to eq ["Anzahl Durchführungen", 4]
+      expect(rows[2]).to eq ["Anzahl Kursstunden", BigDecimal("8.0")]
+      expect(rows[3]).to eq ["Anzahl effektive TeilnehmerInnen", 12]
+      expect(rows[4]).to eq ["davon Personen mit Behinderung", 4]
+      expect(rows[5]).to eq ["davon Angehörige", 8]
+      expect(rows[6]).to eq ["davon nicht Bezugsberechtigte", 0]
+      expect(rows[7]).to eq ["Anzahl Betreuungsstunden", BigDecimal("80.00")]
+      expect(rows[8]).to eq ["Betreuungspersonen", 40]
+      expect(rows[9]).to eq ["Gesamtaufwand direkte Kosten", 240.00]
+      expect(rows[10]).to eq ["davon Honorare", 40.00]
+      expect(rows[11]).to eq ["davon Unterkunft/Raumaufwand", 80.00]
+      expect(rows[12]).to eq ["davon übriger Aufwand inkl. Verpflegung", 120.00]
+      expect(rows[13]).to eq ["Durchschnittliche direkte Kosten pro Betreuungsstunde", 3.0]
+      expect(rows[14]).to eq ["Vollkosten", 280.00]
+      expect(rows[15]).to eq ["Durchschnittliche Vollkosten pro Betreuungsstunde", 3.5]
+      expect(rows[16]).to eq ["Beiträge Teilnehmende", 40.00]
+      expect(rows[17]).to eq ["Betreuungschlüssel (Teilnehmende / Betreuende)", 0.10]
+    end
+  end
+
+  def create_course(leistungskategorie = "bk", group_list: [groups(:be)], year: 2024,
+    fachkonzept: "sport_jugend")
+    Event::Course.create!(groups: group_list,
+      name: "test",
+      leistungskategorie: leistungskategorie, fachkonzept: fachkonzept,
+      dates_attributes: [{start_at: DateTime.new(year, 0o4, 15, 12, 0o0)}])
+  end
+
+  def create!(event, kursart = "freizeit_und_sport", attrs = {})
+    Event::CourseRecord.create!(attrs.merge(event: event, kursart: kursart))
+  end
+
+  def new_aggregration(attrs = {})
+    defaults = {group_id: groups(:be).id,
+                year: year,
+                leistungskategorie: "bk",
+                zugeteilte_kategorie: :unused,
+                subventioniert: [true, false]}
+    fp_class("CourseReporting::Aggregation").new(*defaults.merge(attrs).values)
+  end
+end

--- a/spec/domain/fp2024/export/tabular/course_reporting/client_statistics_spec.rb
+++ b/spec/domain/fp2024/export/tabular/course_reporting/client_statistics_spec.rb
@@ -1,0 +1,420 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024-2024, Insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require "spec_helper"
+
+# siehe auch Fp2015::Export::Tabular::CourseReporting::ClientStatistics
+describe Fp2024::Export::Tabular::CourseReporting::ClientStatistics do
+  let(:year) { 2024 }
+  let(:stats) { fp_class("CourseReporting::ClientStatistics").new(year) }
+
+  let(:exporter) { described_class.new(stats) }
+
+  before do
+    create_course(year, :be, "bk",
+      {be: 1, ag: 2, zh: 3, another: 4},
+      {be: 0, ag: 1, zh: 1, another: 2})
+
+    create_course(year, :be, "bk",
+      {be: 2, ag: 4, zh: 6, another: 8},
+      {be: 1, ag: 2, zh: 3, another: 4},
+      :aggregate_course)
+      .yield_self do |course, course_record|
+        course_record.update!(absenzen_weitere: 1) # leaving only (4 - 1 = 3) "NB" in this course
+      end
+
+    create_course(year, :be, "tp",
+      {be: 1, ag: 1, another: 1},
+      {be: 2, ag: 2, another: 2},
+      :aggregate_course)
+      .yield_self do |course, course_record|
+        course_record.update!(teilnehmende_weitere: 200)
+      end
+
+    create_course(year, :fr, "tk",
+      {be: 1, ag: 1, another: 1})
+
+    create_course(year, :fr, "sk",
+      {be: 1, ag: 1, another: 1})
+
+    create_course(year, :fr, "tp",
+      {be: 1, ag: 1, another: 1})
+      .yield_self do |course, course_record|
+        course_record.update!(teilnehmende_weitere: 200)
+      end
+
+    2.times { create_course(year, :fr, "sk", {}, {}, :course) }
+
+    3.times {
+      create_course(year, :fr, "sk", {}, {}, :course)
+        .yield_self do |course, course_record|
+          course.update!(fachkonzept: "autonomie_foerderung")
+        end
+    }
+
+    4.times { create_course(year, :fr, "sk", {}, {}, :aggregate_course) }
+
+    create_course(year, :fr, "sk", {}, {}, :aggregate_course)
+      .yield_self do |course, course_record|
+        course.update!(fachkonzept: "autonomie_foerderung")
+        course_record.update!(anzahl_kurse: 5)
+      end
+  end
+
+  context "#data_rows" do
+    let(:data) { exporter.data_rows.to_a }
+    let(:nonempty_rows) { data.reject { |row| row.compact.empty? } }
+
+    it "exports columns for all cantons" do
+      prefix = [
+        "Verein / Kurstyp",
+        "Kursinhalt",
+        "Anzahl Kurse",
+        "LE Beitragsberechtigte",
+        "LE Nicht Beitragsberechtigte",
+        "Total"
+      ]
+      expect(exporter.labels.size).to eq(prefix.size + Cantons.short_names.size)
+    end
+
+    it "contains translated headers" do
+      expect(exporter.labels).to match_array([
+        # rubocop:todo Layout/LineLength
+        "Verein / Kurstyp", "Kursinhalt", "Anzahl Kurse", "LE Beitragsberechtigte", "LE Nicht Beitragsberechtigte", "Total",
+        # rubocop:enable Layout/LineLength
+        "AG", "AI", "AR", "BE", "BL", "BS", "FR", "GE", "GL", "GR", "JU", "LU", "NE",
+        "NW", "OW", "SG", "SH", "SO", "SZ", "TG", "TI", "UR", "VD", "VS", "ZG", "ZH",
+        "Andere Herkunft"
+      ])
+    end
+
+    it "exports rows for each group" do
+      groups = Group.by_bsv_number
+
+      expect(nonempty_rows.size).to eq((1 + (2 * 3) + 1) * groups.size)
+    end
+
+    it "contains correct sums" do
+      # rubocop:todo Layout/LineLength
+      #                                                         'kursinhalt'    Kurse  Std  NB  'Sum' 'AG' 'AI' 'AR' 'BE' 'BL' 'BS' 'FR' 'GE' 'GL' 'GR' 'JU' 'LU' 'NE' 'NW' 'OW' 'SG' 'SH' 'SO' 'SZ' 'TG' 'TI' 'UR' 'VD' 'VS' 'ZG' 'ZH' 'Andere Herkunft'
+      # rubocop:enable Layout/LineLength
+      expect(data[0]).to match_array(["insieme Schweiz", 2343, nil, nil, nil, nil, nil, nil, nil,
+        # rubocop:todo Layout/LineLength
+        nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
+      # rubocop:enable Layout/LineLength
+      expect(data[1]).to match_array(["Semester-/Jahreskurse", "Weiterbildung", nil, nil, nil, nil,
+        # rubocop:todo Layout/LineLength
+        nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
+      # rubocop:enable Layout/LineLength
+      expect(data[2]).to match_array(["Semester-/Jahreskurse", "Sport/Freizeit", nil, nil, nil,
+        # rubocop:todo Layout/LineLength
+        nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
+      # rubocop:enable Layout/LineLength
+      expect(data[3]).to match_array(["Blockkurse", "Weiterbildung", nil, nil, nil, nil, nil, nil,
+        # rubocop:todo Layout/LineLength
+        nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
+      # rubocop:enable Layout/LineLength
+      expect(data[4]).to match_array(["Blockkurse", "Sport/Freizeit", nil, nil, nil, nil, nil, nil,
+        # rubocop:todo Layout/LineLength
+        nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
+      # rubocop:enable Layout/LineLength
+      expect(data[5]).to match_array(["Tageskurse", "Weiterbildung", nil, nil, nil, nil, nil, nil,
+        # rubocop:todo Layout/LineLength
+        nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
+      # rubocop:enable Layout/LineLength
+      expect(data[6]).to match_array(["Tageskurse", "Sport/Freizeit", nil, nil, nil, nil, nil, nil,
+        # rubocop:todo Layout/LineLength
+        nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
+      # rubocop:enable Layout/LineLength
+      expect(data[7]).to match_array(["Treffpunkte", "Treffpunkt", nil, nil, nil, nil, nil, nil,
+        # rubocop:todo Layout/LineLength
+        nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
+      # rubocop:enable Layout/LineLength
+      expect(data[8]).to match_array([nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+        # rubocop:todo Layout/LineLength
+        nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
+      # rubocop:enable Layout/LineLength
+      expect(data[9]).to match_array(["Kanton Bern", 2024, nil, nil, nil, nil, nil, nil, nil, nil,
+        # rubocop:todo Layout/LineLength
+        nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
+      # rubocop:enable Layout/LineLength
+      expect(data[10]).to match_array(["Semester-/Jahreskurse", "Weiterbildung", nil, nil, nil,
+        # rubocop:todo Layout/LineLength
+        nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
+      # rubocop:enable Layout/LineLength
+      expect(data[11]).to match_array(["Semester-/Jahreskurse", "Sport/Freizeit", nil, nil, nil,
+        # rubocop:todo Layout/LineLength
+        nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
+      # rubocop:enable Layout/LineLength
+      expect(data[12]).to match_array(["Blockkurse", "Weiterbildung", nil, nil, nil, nil, nil, nil,
+        # rubocop:todo Layout/LineLength
+        nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
+      # rubocop:enable Layout/LineLength
+      expect(data[13]).to match_array(["Blockkurse", "Sport/Freizeit", 2, 28, 5, 44, 9, nil, nil,
+        # rubocop:todo Layout/LineLength
+        4, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 13, 18])
+      # rubocop:enable Layout/LineLength
+      expect(data[14]).to match_array(["Tageskurse", "Weiterbildung", nil, nil, nil, nil, nil, nil,
+        # rubocop:todo Layout/LineLength
+        nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
+      # rubocop:enable Layout/LineLength
+      expect(data[15]).to match_array(["Tageskurse", "Sport/Freizeit", nil, nil, nil, nil, nil,
+        # rubocop:todo Layout/LineLength
+        nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
+      # rubocop:enable Layout/LineLength
+      expect(data[16]).to match_array(["Treffpunkte", "Treffpunkt", 1, nil, nil, 9, 3, nil, nil, 3,
+        # rubocop:todo Layout/LineLength
+        nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 3])
+      # rubocop:enable Layout/LineLength
+      expect(data[17]).to match_array([nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+        # rubocop:todo Layout/LineLength
+        nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
+      # rubocop:enable Layout/LineLength
+      expect(data[18]).to match_array(["Biel-Seeland", 3115, nil, nil, nil, nil, nil, nil, nil,
+        # rubocop:todo Layout/LineLength
+        nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
+      # rubocop:enable Layout/LineLength
+      expect(data[19]).to match_array(["Semester-/Jahreskurse", "Weiterbildung", nil, nil, nil,
+        # rubocop:todo Layout/LineLength
+        nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
+      # rubocop:enable Layout/LineLength
+      expect(data[20]).to match_array(["Semester-/Jahreskurse", "Sport/Freizeit", nil, nil, nil,
+        # rubocop:todo Layout/LineLength
+        nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
+      # rubocop:enable Layout/LineLength
+      expect(data[21]).to match_array(["Blockkurse", "Weiterbildung", nil, nil, nil, nil, nil, nil,
+        # rubocop:todo Layout/LineLength
+        nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
+      # rubocop:enable Layout/LineLength
+      expect(data[22]).to match_array(["Blockkurse", "Sport/Freizeit", nil, nil, nil, nil, nil,
+        # rubocop:todo Layout/LineLength
+        nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
+      # rubocop:enable Layout/LineLength
+      expect(data[23]).to match_array(["Tageskurse", "Weiterbildung", nil, nil, nil, nil, nil, nil,
+        # rubocop:todo Layout/LineLength
+        nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
+      # rubocop:enable Layout/LineLength
+      expect(data[24]).to match_array(["Tageskurse", "Sport/Freizeit", nil, nil, nil, nil, nil,
+        # rubocop:todo Layout/LineLength
+        nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
+      # rubocop:enable Layout/LineLength
+      expect(data[25]).to match_array(["Treffpunkte", "Treffpunkt", nil, nil, nil, nil, nil, nil,
+        # rubocop:todo Layout/LineLength
+        nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
+      # rubocop:enable Layout/LineLength
+      expect(data[26]).to match_array([nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+        # rubocop:todo Layout/LineLength
+        nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
+      # rubocop:enable Layout/LineLength
+      expect(data[27]).to match_array(["Freiburg", 12607, nil, nil, nil, nil, nil, nil, nil, nil,
+        # rubocop:todo Layout/LineLength
+        nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
+      # rubocop:enable Layout/LineLength
+      expect(data[28]).to match_array(["Semester-/Jahreskurse", "Weiterbildung", 8, nil, nil, nil,
+        # rubocop:todo Layout/LineLength
+        nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
+      # rubocop:enable Layout/LineLength
+      expect(data[29]).to match_array(["Semester-/Jahreskurse", "Sport/Freizeit", 7, 6, nil, 3, 1,
+        # rubocop:todo Layout/LineLength
+        nil, nil, 1, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 1])
+      # rubocop:enable Layout/LineLength
+      expect(data[30]).to match_array(["Blockkurse", "Weiterbildung", nil, nil, nil, nil, nil, nil,
+        # rubocop:todo Layout/LineLength
+        nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
+      # rubocop:enable Layout/LineLength
+      expect(data[31]).to match_array(["Blockkurse", "Sport/Freizeit", nil, nil, nil, nil, nil,
+        # rubocop:todo Layout/LineLength
+        nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
+      # rubocop:enable Layout/LineLength
+      expect(data[32]).to match_array(["Tageskurse", "Weiterbildung", nil, nil, nil, nil, nil, nil,
+        # rubocop:todo Layout/LineLength
+        nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
+      # rubocop:enable Layout/LineLength
+      expect(data[33]).to match_array(["Tageskurse", "Sport/Freizeit", 1, 6, nil, 3, 1, nil, nil,
+        # rubocop:todo Layout/LineLength
+        1, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 1])
+      # rubocop:enable Layout/LineLength
+      expect(data[34]).to match_array(["Treffpunkte", "Treffpunkt", 1, nil, nil, 3, 1, nil, nil, 1,
+        # rubocop:todo Layout/LineLength
+        nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 1])
+      # rubocop:enable Layout/LineLength
+      # rubocop:todo Layout/LineLength
+      #                                                         'kursinhalt'    Kurse  Std  NB  'Sum' 'AG' 'AI' 'AR' 'BE' 'BL' 'BS' 'FR' 'GE' 'GL' 'GR' 'JU' 'LU' 'NE' 'NW' 'OW' 'SG' 'SH' 'SO' 'SZ' 'TG' 'TI' 'UR' 'VD' 'VS' 'ZG' 'ZH' 'Andere Herkunft'
+      # rubocop:enable Layout/LineLength
+    end
+  end
+
+  it "contain correct sums according to client-setup" do
+    year = 2021
+    stats = fp_class("CourseReporting::ClientStatistics").new(year)
+    exporter = described_class.new(stats)
+
+    create_course(year, :seeland, "sk", {be: 15}).tap do |course, record|
+      course.update!(fachkonzept: "autonomie_foerderung")
+      record.update!(
+        kursart: "weiterbildung",
+        kursdauer: 10,
+        teilnehmende_weitere: 1
+      )
+    end
+
+    create_course(year, :seeland, "bk", {be: 40}, {be: 10},
+      :aggregate_course).tap do |course, record|
+      record.update!(
+        anzahl_kurse: 3,
+        kursdauer: 15,
+        teilnehmende_weitere: 0,
+        absenzen_behinderte: 5.0,
+        tage_behinderte: 30.0,
+        tage_angehoerige: 15.0,
+        tage_weitere: 3.0
+      )
+    end
+
+    create_course(year, :seeland, "tk", {be: 20}).tap do |_, record|
+      record.update!({
+        kursdauer: 1,
+        teilnehmende_weitere: 0
+      })
+    end
+
+    create_course(year, :seeland, "tp", {be: 20}, {}, :aggregate_course).tap do |course, record|
+      record.update!(
+        anzahl_kurse: 5,
+        kursdauer: 50,
+        tage_weitere: 17, # shall not be reflected in the output
+        betreuerinnen: 5,
+        betreuungsstunden: 75
+      )
+    end
+
+    data = exporter.data_rows.to_a
+
+    #                             Verein / Kurstyp         Kursinhalt        Anz  LE   NB  Total
+    expect(data[18][0..5]).to eq ["Biel-Seeland", 3115, nil, nil, nil, nil]
+    expect(data[19][0..5]).to eq ["Semester-/Jahreskurse", "Weiterbildung", 1, 150, 10, 15]
+    expect(data[20][0..5]).to eq ["Semester-/Jahreskurse", "Sport/Freizeit", nil, nil, nil, nil]
+    expect(data[21][0..5]).to eq ["Blockkurse", "Weiterbildung", nil, nil, nil, nil]
+    expect(data[22][0..5]).to eq ["Blockkurse", "Sport/Freizeit", 3, 45, 3, 50]
+    expect(data[23][0..5]).to eq ["Tageskurse", "Weiterbildung", nil, nil, nil, nil]
+    expect(data[24][0..5]).to eq ["Tageskurse", "Sport/Freizeit", 1, 20, nil, 20]
+    expect(data[25][0..5]).to eq ["Treffpunkte", "Treffpunkt", 5, 75, nil, 20]
+  end
+
+  it "calculates aggregate_courses correctly" do
+    year = 2024
+    stats = fp_class("CourseReporting::ClientStatistics").new(year)
+    exporter = described_class.new(stats)
+
+    create_course(year, :seeland, "sk", {}, {}, :course).tap do |course, course_record|
+      course.update!(fachkonzept: "autonomie_foerderung")
+    end
+
+    create_course(year, :seeland, "sk", {}, {}, :course).tap do |course, course_record|
+      course.update!(fachkonzept: "autonomie_foerderung")
+    end
+
+    create_course(year, :seeland, "sk", {}, {}, :course).tap do |course, course_record|
+      course.update!(fachkonzept: "autonomie_foerderung")
+    end
+
+    create_course(year, :seeland, "sk", {}, {}, :aggregate_course).tap do |course, record|
+      course.update!(fachkonzept: "autonomie_foerderung")
+      record.update!(
+        anzahl_kurse: 3
+      )
+    end
+
+    gcp = stats.group_participants(groups(:seeland).id, "sk", "weiterbildung")
+    expect(gcp.course_count).to eq 6
+
+    data = exporter.data_rows.to_a
+
+    #                             Verein / Kurstyp         Kursinhalt        Anz  LE   NB  Total
+    expect(data[18][0..5]).to eq ["Biel-Seeland", 3115, nil, nil, nil, nil]
+    expect(data[19][0..5]).to eq ["Semester-/Jahreskurse", "Weiterbildung", 6, nil, nil, nil]
+    expect(data[20][0..5]).to eq ["Semester-/Jahreskurse", "Sport/Freizeit", nil, nil, nil, nil]
+    expect(data[21][0..5]).to eq ["Blockkurse", "Weiterbildung", nil, nil, nil, nil]
+    expect(data[22][0..5]).to eq ["Blockkurse", "Sport/Freizeit", nil, nil, nil, nil]
+    expect(data[23][0..5]).to eq ["Tageskurse", "Weiterbildung", nil, nil, nil, nil]
+    expect(data[24][0..5]).to eq ["Tageskurse", "Sport/Freizeit", nil, nil, nil, nil]
+    expect(data[25][0..5]).to eq ["Treffpunkte", "Treffpunkt", nil, nil, nil, nil]
+  end
+
+  context "adds grundlagen hours to course_hours" do
+    let(:group) { groups(:be) }
+
+    let!(:employee_time) do
+      TimeRecord::EmployeeTime.create!(
+        group_id: group.id, year: year, kurse_grundlagen: 20, treffpunkte_grundlagen: 30
+      )
+    end
+    let!(:volunteer_time) do
+      TimeRecord::VolunteerWithoutVerificationTime.create!(
+        group_id: group.id, year: year, kurse_grundlagen: 44, treffpunkte_grundlagen: 55
+      )
+    end
+
+    let(:treffpunkte_gcp) do
+      Fp2024::CourseReporting::ClientStatistics::GroupCantonParticipant.new(
+        group.id, "tp", "treffpunkt", 5, 75, 0, *Array.new(27) { 0 }
+      )
+    end
+
+    let(:kurse_gcp) do
+      Fp2024::CourseReporting::ClientStatistics::GroupCantonParticipant.new(
+        group.id, "sk", "freizeit_jugend", 5, 85, 0, *Array.new(27) { 0 }
+      )
+    end
+
+    [:treffpunkte, :kurse].each do |kind|
+      it "for #{kind}" do
+        # collaborators
+        stats = double("client-statistics", year: year)
+
+        # execute
+        result = described_class.new(stats)
+          .send(:course_hours_including_grundlagen_hours, send(:"#{kind}_gcp"))
+
+        expected = send(:"#{kind}_gcp").course_hours + employee_time.send(:"#{kind}_grundlagen")
+        expect(result).to be_within(0.001).of(expected)
+      end
+    end
+  end
+
+  private
+
+  # rubocop:todo Metrics/MethodLength
+  # rubocop:todo Metrics/AbcSize
+  def create_course(year, group, leistungskategorie, challenged = {}, affiliated = {},
+    event_type = :course)
+    fachkonzept = (leistungskategorie == "tp") ? "treffpunkt" : "sport_jugend"
+    if event_type == :aggregate_course
+      event = Fabricate(event_type,
+        leistungskategorie: leistungskategorie,
+        fachkonzept: fachkonzept,
+        year: year)
+      event.update(group_ids: [groups(group).id])
+    else
+      event = Fabricate(event_type,
+        leistungskategorie: leistungskategorie, fachkonzept: fachkonzept)
+      event.update(group_ids: [groups(group).id])
+      event.dates.create!(start_at: Time.zone.local(year, 0o5, 11))
+    end
+    r = Event::CourseRecord.create!(event_id: event.id, year: year)
+    r.create_challenged_canton_count!(challenged) if challenged.present?
+    r.create_affiliated_canton_count!(affiliated) if affiliated.present?
+    r.update!({
+      kursdauer: 2,
+      teilnehmende_mehrfachbehinderte: challenged.values.sum / 2,
+      teilnehmende_weitere: (challenged.values.sum / 10).floor
+    })
+    [event, r]
+  end
+  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/MethodLength
+end

--- a/spec/domain/fp2024/export/tabular/statistics/group_figures_spec.rb
+++ b/spec/domain/fp2024/export/tabular/statistics/group_figures_spec.rb
@@ -1,0 +1,585 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024-2023, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require "spec_helper"
+
+describe Fp2024::Export::Tabular::Statistics::GroupFigures do
+  let(:year) { 2024 }
+
+  before do
+    TimeRecord::EmployeeTime.create!(group: groups(:be),
+      year: year,
+      interviews: 10,
+      beratung: 9,
+      kurse_grundlagen: 8,
+      employee_pensum_attributes: {paragraph_74: 0.25})
+    TimeRecord::EmployeeTime.create!(group: groups(:be), year: year - 1, newsletter: 11)
+    TimeRecord::EmployeeTime.create!(group: groups(:fr),
+      year: year,
+      projekte: 12,
+      employee_pensum_attributes: {
+        paragraph_74: 1.6, not_paragraph_74: 0.4
+      })
+
+    TimeRecord::VolunteerWithVerificationTime.create!(
+      group: groups(:be), year: year, vermittlung_kontakte: 20, treffpunkte_grundlagen: 21
+    )
+    TimeRecord::VolunteerWithVerificationTime.create!(
+      group: groups(:fr), year: year, referate: 21
+    )
+
+    TimeRecord::VolunteerWithoutVerificationTime.create!(
+      group: groups(:be), year: year, total_lufeb_promoting: 30
+    )
+
+    CostAccountingRecord.create!(group: groups(:be), year: year, report: "raumaufwand",
+      raeumlichkeiten: 100)
+    CostAccountingRecord.create!(group: groups(:be), year: year, report: "honorare",
+      aufwand_ertrag_fibu: 100, verwaltung: 10,
+      beratung: 30)
+    CostAccountingRecord.create!(group: groups(:be), year: year, report: "leistungsertrag",
+      aufwand_ertrag_fibu: 100, abgrenzung_fibu: 80,
+      lufeb: 20)
+    CostAccountingRecord.create!(group: groups(:be), year: year, report: "direkte_spenden",
+      aufwand_ertrag_fibu: 10, lufeb: 2, tageskurse: 8)
+    CostAccountingRecord.create!(group: groups(:be), year: year, report: "beitraege_iv",
+      aufwand_ertrag_fibu: 100, abgrenzung_fibu: 80,
+      lufeb: 20)
+
+    CapitalSubstrate.create!(
+      group: groups(:be), year: year, organization_capital: 500_000
+    )
+    CapitalSubstrate.create!(
+      group: groups(:fr), year: year, organization_capital: 250_000
+    )
+
+    create_course(year, :be, "bk", "1", kursdauer: 10, unterkunft: 500,
+      challenged_canton_count_attributes: {zh: 100})
+    create_course(year, :be, "bk", "1", kursdauer: 11, gemeinkostenanteil: 600,
+      affiliated_canton_count_attributes: {zh: 101})
+    create_course(year, :be, "bk", "2", kursdauer: 12, unterkunft: 800,
+      challenged_canton_count_attributes: {zh: 450})
+    create_course(year, :be, "bk", "3", kursdauer: 13, teilnehmende_weitere: 650, uebriges: 200)
+    create_course(year, :be, "sk", "1", kursdauer: 14, unterkunft: 400,
+      honorare_inkl_sozialversicherung: 10,
+      challenged_canton_count_attributes: {zh: 102})
+    create_course(year, :fr, "bk", "1", kursdauer: 15, unterkunft: 0,
+      challenged_canton_count_attributes: {zh: 103})
+    create_course(year, :fr, "tk", "1", kursdauer: 16, teilnehmende_weitere: 104, unterkunft: 500)
+    create_course(year, :fr, "tk", "3", kursdauer: 17, uebriges: 600,
+      challenged_canton_count_attributes: {zh: 500})
+    create_course(year, :fr, "tp", "1", kursdauer: 18, betreuerinnen: 2)
+
+    # other year
+    create_course(year - 1, :fr, "bk", "1", kursdauer: 17, teilnehmende_weitere: 105)
+  end
+
+  let(:figures) { fp_class("Statistics::GroupFigures").new(year) }
+
+  let(:subject) { described_class.new(figures) }
+
+  it "contains correct headers in order" do
+    labels = subject.labels
+    expected = [
+      "Vollständiger Name",
+      "Kanton",
+      "VID",
+      "BSV Nummer",
+
+      "Blockkurse Anzahl Kurse Freizeit Kinder & Jugendliche",
+      "Blockkurse Total Vollkosten Freizeit Kinder & Jugendliche",
+      "Blockkurse TN Tage Personen mit Behinderung Freizeit Kinder & Jugendliche",
+      "Blockkurse TN Tage Angehörige Freizeit Kinder & Jugendliche",
+      "Blockkurse TN Tage nicht Bezugsberechtigte Freizeit Kinder & Jugendliche",
+      "Blockkurse TN Tage Total Freizeit Kinder & Jugendliche",
+
+      "Blockkurse Anzahl Kurse Freizeit Erwachsene & altersdurchmischt",
+      "Blockkurse Total Vollkosten Freizeit Erwachsene & altersdurchmischt",
+      "Blockkurse TN Tage Personen mit Behinderung Freizeit Erwachsene & altersdurchmischt",
+      "Blockkurse TN Tage Angehörige Freizeit Erwachsene & altersdurchmischt",
+      "Blockkurse TN Tage nicht Bezugsberechtigte Freizeit Erwachsene & altersdurchmischt",
+      "Blockkurse TN Tage Total Freizeit Erwachsene & altersdurchmischt",
+
+      "Blockkurse Anzahl Kurse Sport Kinder & Jugendliche",
+      "Blockkurse Total Vollkosten Sport Kinder & Jugendliche",
+      "Blockkurse TN Tage Personen mit Behinderung Sport Kinder & Jugendliche",
+      "Blockkurse TN Tage Angehörige Sport Kinder & Jugendliche",
+      "Blockkurse TN Tage nicht Bezugsberechtigte Sport Kinder & Jugendliche",
+      "Blockkurse TN Tage Total Sport Kinder & Jugendliche",
+
+      "Blockkurse Anzahl Kurse Sport Erwachsene & altersdurchmischt",
+      "Blockkurse Total Vollkosten Sport Erwachsene & altersdurchmischt",
+      "Blockkurse TN Tage Personen mit Behinderung Sport Erwachsene & altersdurchmischt",
+      "Blockkurse TN Tage Angehörige Sport Erwachsene & altersdurchmischt",
+      "Blockkurse TN Tage nicht Bezugsberechtigte Sport Erwachsene & altersdurchmischt",
+      "Blockkurse TN Tage Total Sport Erwachsene & altersdurchmischt",
+
+      "Blockkurse Anzahl Kurse Förderung der Autonomie/Bildung",
+      "Blockkurse Total Vollkosten Förderung der Autonomie/Bildung",
+      "Blockkurse TN Tage Personen mit Behinderung Förderung der Autonomie/Bildung",
+      "Blockkurse TN Tage Angehörige Förderung der Autonomie/Bildung",
+      "Blockkurse TN Tage nicht Bezugsberechtigte Förderung der Autonomie/Bildung",
+      "Blockkurse TN Tage Total Förderung der Autonomie/Bildung",
+
+      "Tageskurse Anzahl Kurse Freizeit Kinder & Jugendliche",
+      "Tageskurse Total Vollkosten Freizeit Kinder & Jugendliche",
+      "Tageskurse TN Tage Personen mit Behinderung Freizeit Kinder & Jugendliche",
+      "Tageskurse TN Tage Angehörige Freizeit Kinder & Jugendliche",
+      "Tageskurse TN Tage nicht Bezugsberechtigte Freizeit Kinder & Jugendliche",
+      "Tageskurse TN Tage Total Freizeit Kinder & Jugendliche",
+
+      "Tageskurse Anzahl Kurse Freizeit Erwachsene & altersdurchmischt",
+      "Tageskurse Total Vollkosten Freizeit Erwachsene & altersdurchmischt",
+      "Tageskurse TN Tage Personen mit Behinderung Freizeit Erwachsene & altersdurchmischt",
+      "Tageskurse TN Tage Angehörige Freizeit Erwachsene & altersdurchmischt",
+      "Tageskurse TN Tage nicht Bezugsberechtigte Freizeit Erwachsene & altersdurchmischt",
+      "Tageskurse TN Tage Total Freizeit Erwachsene & altersdurchmischt",
+
+      "Tageskurse Anzahl Kurse Sport Kinder & Jugendliche",
+      "Tageskurse Total Vollkosten Sport Kinder & Jugendliche",
+      "Tageskurse TN Tage Personen mit Behinderung Sport Kinder & Jugendliche",
+      "Tageskurse TN Tage Angehörige Sport Kinder & Jugendliche",
+      "Tageskurse TN Tage nicht Bezugsberechtigte Sport Kinder & Jugendliche",
+      "Tageskurse TN Tage Total Sport Kinder & Jugendliche",
+
+      "Tageskurse Anzahl Kurse Sport Erwachsene & altersdurchmischt",
+      "Tageskurse Total Vollkosten Sport Erwachsene & altersdurchmischt",
+      "Tageskurse TN Tage Personen mit Behinderung Sport Erwachsene & altersdurchmischt",
+      "Tageskurse TN Tage Angehörige Sport Erwachsene & altersdurchmischt",
+      "Tageskurse TN Tage nicht Bezugsberechtigte Sport Erwachsene & altersdurchmischt",
+      "Tageskurse TN Tage Total Sport Erwachsene & altersdurchmischt",
+
+      "Tageskurse Anzahl Kurse Förderung der Autonomie/Bildung",
+      "Tageskurse Total Vollkosten Förderung der Autonomie/Bildung",
+      "Tageskurse TN Tage Personen mit Behinderung Förderung der Autonomie/Bildung",
+      "Tageskurse TN Tage Angehörige Förderung der Autonomie/Bildung",
+      "Tageskurse TN Tage nicht Bezugsberechtigte Förderung der Autonomie/Bildung",
+      "Tageskurse TN Tage Total Förderung der Autonomie/Bildung",
+
+      "Semester-/Jahreskurse Anzahl Kurse Freizeit Kinder & Jugendliche",
+      "Semester-/Jahreskurse Total Vollkosten Freizeit Kinder & Jugendliche",
+      "Semester-/Jahreskurse TN Tage Personen mit Behinderung Freizeit Kinder & Jugendliche",
+      "Semester-/Jahreskurse TN Tage Angehörige Freizeit Kinder & Jugendliche",
+      "Semester-/Jahreskurse TN Tage nicht Bezugsberechtigte Freizeit Kinder & Jugendliche",
+      "Semester-/Jahreskurse TN Tage Total Freizeit Kinder & Jugendliche",
+
+      "Semester-/Jahreskurse Anzahl Kurse Freizeit Erwachsene & altersdurchmischt",
+      "Semester-/Jahreskurse Total Vollkosten Freizeit Erwachsene & altersdurchmischt",
+      # rubocop:todo Layout/LineLength
+      "Semester-/Jahreskurse TN Tage Personen mit Behinderung Freizeit Erwachsene & altersdurchmischt",
+      # rubocop:enable Layout/LineLength
+      "Semester-/Jahreskurse TN Tage Angehörige Freizeit Erwachsene & altersdurchmischt",
+      # rubocop:todo Layout/LineLength
+      "Semester-/Jahreskurse TN Tage nicht Bezugsberechtigte Freizeit Erwachsene & altersdurchmischt",
+      # rubocop:enable Layout/LineLength
+      "Semester-/Jahreskurse TN Tage Total Freizeit Erwachsene & altersdurchmischt",
+
+      "Semester-/Jahreskurse Anzahl Kurse Sport Kinder & Jugendliche",
+      "Semester-/Jahreskurse Total Vollkosten Sport Kinder & Jugendliche",
+      "Semester-/Jahreskurse TN Tage Personen mit Behinderung Sport Kinder & Jugendliche",
+      "Semester-/Jahreskurse TN Tage Angehörige Sport Kinder & Jugendliche",
+      "Semester-/Jahreskurse TN Tage nicht Bezugsberechtigte Sport Kinder & Jugendliche",
+      "Semester-/Jahreskurse TN Tage Total Sport Kinder & Jugendliche",
+
+      "Semester-/Jahreskurse Anzahl Kurse Sport Erwachsene & altersdurchmischt",
+      "Semester-/Jahreskurse Total Vollkosten Sport Erwachsene & altersdurchmischt",
+      "Semester-/Jahreskurse TN Tage Personen mit Behinderung Sport Erwachsene & altersdurchmischt",
+      "Semester-/Jahreskurse TN Tage Angehörige Sport Erwachsene & altersdurchmischt",
+      "Semester-/Jahreskurse TN Tage nicht Bezugsberechtigte Sport Erwachsene & altersdurchmischt",
+      "Semester-/Jahreskurse TN Tage Total Sport Erwachsene & altersdurchmischt",
+
+      "Semester-/Jahreskurse Anzahl Kurse Förderung der Autonomie/Bildung",
+      "Semester-/Jahreskurse Total Vollkosten Förderung der Autonomie/Bildung",
+      "Semester-/Jahreskurse TN Tage Personen mit Behinderung Förderung der Autonomie/Bildung",
+      "Semester-/Jahreskurse TN Tage Angehörige Förderung der Autonomie/Bildung",
+      "Semester-/Jahreskurse TN Tage nicht Bezugsberechtigte Förderung der Autonomie/Bildung",
+      "Semester-/Jahreskurse TN Tage Total Förderung der Autonomie/Bildung",
+
+      "Treffpunkte Anzahl Kurse Treffpunkt",
+      "Treffpunkte Total Vollkosten Treffpunkt",
+      "Treffpunkte TN Tage Personen mit Behinderung Treffpunkt",
+      "Treffpunkte TN Tage Angehörige Treffpunkt",
+      "Treffpunkte TN Tage nicht Bezugsberechtigte Treffpunkt",
+      "Treffpunkte TN Tage Total Treffpunkt",
+      "Treffpunkte Betreuungsstunden Total Treffpunkt",
+
+      "Stunden Angestellte: Grundlagenarbeit Kurse",
+      "Stunden Angestellte: Grundlagenarbeit Treffpunkte",
+      "LUFEB Stunden Angestellte: Grundlagenarbeit zu LUFEB",
+      "LUFEB Stunden Angestellte: Förderung der Selbsthilfe",
+      "LUFEB Stunden Angestellte: Allgemeine Medien & Öffentlichkeitsarbeit",
+      "LUFEB Stunden Angestellte: Themenspezifische Grundlagenarbeit",
+      "Stunden Angestellte: Grundlagenarbeit Medien & Publikationen",
+      "Stunden Angestellte: Medien & Publikationen",
+      "Stunden Angestellte: Sozialberatung",
+
+      "Stunden Ehrenamtliche mit Leistungsausweis: Grundlagenarbeit Kurse",
+      "Stunden Ehrenamtliche mit Leistungsausweis: Grundlagenarbeit Treffpunkte",
+      "LUFEB Stunden Ehrenamtliche mit Leistungsausweis: Grundlagenarbeit zu LUFEB",
+      "LUFEB Stunden Ehrenamtliche mit Leistungsausweis: Förderung der Selbsthilfe",
+      "LUFEB Stunden Ehrenamtliche mit Leistungsausweis: Allgemeine Medien & Öffentlichkeitsarbeit",
+      "LUFEB Stunden Ehrenamtliche mit Leistungsausweis: Themenspezifische Grundlagenarbeit",
+      "Stunden Ehrenamtliche mit Leistungsausweis: Grundlagenarbeit Medien & Publikationen",
+      "Stunden Ehrenamtliche mit Leistungsausweis: Medien & Publikationen",
+      "Stunden Ehrenamtliche mit Leistungsausweis: Sozialberatung",
+
+      "LUFEB Stunden Ehrenamtliche ohne Leistungsausweis (Total)",
+      "Stunden Ehrenamtliche ohne Leistungsausweis: Sozialberatung",
+
+      "VZÄ angestellte Mitarbeiter (ganze Organisation)",
+      "VZÄ angestellte Mitarbeiter (Art. 74)",
+      "VZÄ ehrenamtliche Mitarbeiter (ganze Organisation)",
+      "VZÄ ehrenamtliche Mitarbeiter (Art. 74)",
+      "VZÄ ehrenamtliche Mitarbeiter mit Leistungsausweis (Art. 74)",
+
+      "Geschlüsseltes Kapitalsubstrat nach Art. 74",
+      "Faktor Kapitalsubstrat",
+      "Totaler Aufwand gemäss FIBU",
+      "Vollkosten nach Umlagen Betrieb Art. 74",
+      "IV-Beitrag",
+      "Deckungsbeitrag 4",
+      "IV-Finanzierungsgrad #{year}"
+    ]
+    expect(labels).to match_array expected
+    expect(labels).to eq expected
+  end
+
+  context "contains correct summed values" do
+    let(:data) do
+      subject.data_rows.to_a
+        .each { |row| row.map! { |value| value.is_a?(BigDecimal) ? value.to_f.round(5) : value } }
+        .map { |row| subject.labels.zip(row).to_h }
+    end
+
+    let(:empty_row) do
+      {
+        "BSV Nummer" => nil,
+        "Blockkurse Anzahl Kurse Freizeit Erwachsene & altersdurchmischt" => 0,
+        "Blockkurse Anzahl Kurse Freizeit Kinder & Jugendliche" => 0,
+        "Blockkurse Anzahl Kurse Förderung der Autonomie/Bildung" => 0,
+        "Blockkurse Anzahl Kurse Sport Erwachsene & altersdurchmischt" => 0,
+        "Blockkurse Anzahl Kurse Sport Kinder & Jugendliche" => 0,
+        "Blockkurse TN Tage Angehörige Freizeit Erwachsene & altersdurchmischt" => 0.0,
+        "Blockkurse TN Tage Angehörige Freizeit Kinder & Jugendliche" => 0.0,
+        "Blockkurse TN Tage Angehörige Förderung der Autonomie/Bildung" => 0.0,
+        "Blockkurse TN Tage Angehörige Sport Erwachsene & altersdurchmischt" => 0.0,
+        "Blockkurse TN Tage Angehörige Sport Kinder & Jugendliche" => 0.0,
+        # rubocop:todo Layout/LineLength
+        "Blockkurse TN Tage Personen mit Behinderung Freizeit Erwachsene & altersdurchmischt" => 0.0,
+        # rubocop:enable Layout/LineLength
+        "Blockkurse TN Tage Personen mit Behinderung Freizeit Kinder & Jugendliche" => 0.0,
+        "Blockkurse TN Tage Personen mit Behinderung Förderung der Autonomie/Bildung" => 0.0,
+        "Blockkurse TN Tage Personen mit Behinderung Sport Erwachsene & altersdurchmischt" => 0.0,
+        "Blockkurse TN Tage Personen mit Behinderung Sport Kinder & Jugendliche" => 0.0,
+        "Blockkurse TN Tage Total Freizeit Erwachsene & altersdurchmischt" => 0.0,
+        "Blockkurse TN Tage Total Freizeit Kinder & Jugendliche" => 0.0,
+        "Blockkurse TN Tage Total Förderung der Autonomie/Bildung" => 0.0,
+        "Blockkurse TN Tage Total Sport Erwachsene & altersdurchmischt" => 0.0,
+        "Blockkurse TN Tage Total Sport Kinder & Jugendliche" => 0.0,
+        "Blockkurse TN Tage nicht Bezugsberechtigte Freizeit Erwachsene & altersdurchmischt" => 0.0,
+        "Blockkurse TN Tage nicht Bezugsberechtigte Freizeit Kinder & Jugendliche" => 0.0,
+        "Blockkurse TN Tage nicht Bezugsberechtigte Förderung der Autonomie/Bildung" => 0.0,
+        "Blockkurse TN Tage nicht Bezugsberechtigte Sport Erwachsene & altersdurchmischt" => 0.0,
+        "Blockkurse TN Tage nicht Bezugsberechtigte Sport Kinder & Jugendliche" => 0.0,
+        "Blockkurse Total Vollkosten Freizeit Erwachsene & altersdurchmischt" => 0.0,
+        "Blockkurse Total Vollkosten Freizeit Kinder & Jugendliche" => 0.0,
+        "Blockkurse Total Vollkosten Förderung der Autonomie/Bildung" => 0.0,
+        "Blockkurse Total Vollkosten Sport Erwachsene & altersdurchmischt" => 0.0,
+        "Blockkurse Total Vollkosten Sport Kinder & Jugendliche" => 0.0,
+        "Deckungsbeitrag 4" => 0.0,
+        "Faktor Kapitalsubstrat" => 0.0,
+        "Geschlüsseltes Kapitalsubstrat nach Art. 74" => 0.0,
+        "IV-Beitrag" => 0.0,
+        "IV-Finanzierungsgrad #{year}" => 0.0,
+        "Kanton" => nil,
+        "LUFEB Stunden Angestellte: Allgemeine Medien & Öffentlichkeitsarbeit" => 0,
+        "LUFEB Stunden Angestellte: Förderung der Selbsthilfe" => 0,
+        "LUFEB Stunden Angestellte: Grundlagenarbeit zu LUFEB" => 0,
+        "LUFEB Stunden Angestellte: Themenspezifische Grundlagenarbeit" => 0,
+        # rubocop:todo Layout/LineLength
+        "LUFEB Stunden Ehrenamtliche mit Leistungsausweis: Allgemeine Medien & Öffentlichkeitsarbeit" => 0,
+        # rubocop:enable Layout/LineLength
+        "LUFEB Stunden Ehrenamtliche mit Leistungsausweis: Förderung der Selbsthilfe" => 0,
+        "LUFEB Stunden Ehrenamtliche mit Leistungsausweis: Grundlagenarbeit zu LUFEB" => 0,
+        "LUFEB Stunden Ehrenamtliche mit Leistungsausweis: Themenspezifische Grundlagenarbeit" => 0,
+        "LUFEB Stunden Ehrenamtliche ohne Leistungsausweis (Total)" => 0,
+        "Semester-/Jahreskurse Anzahl Kurse Freizeit Erwachsene & altersdurchmischt" => 0,
+        "Semester-/Jahreskurse Anzahl Kurse Freizeit Kinder & Jugendliche" => 0,
+        "Semester-/Jahreskurse Anzahl Kurse Förderung der Autonomie/Bildung" => 0,
+        "Semester-/Jahreskurse Anzahl Kurse Sport Erwachsene & altersdurchmischt" => 0,
+        "Semester-/Jahreskurse Anzahl Kurse Sport Kinder & Jugendliche" => 0,
+        "Semester-/Jahreskurse TN Tage Angehörige Freizeit Erwachsene & altersdurchmischt" => 0.0,
+        "Semester-/Jahreskurse TN Tage Angehörige Freizeit Kinder & Jugendliche" => 0.0,
+        "Semester-/Jahreskurse TN Tage Angehörige Förderung der Autonomie/Bildung" => 0.0,
+        "Semester-/Jahreskurse TN Tage Angehörige Sport Erwachsene & altersdurchmischt" => 0.0,
+        "Semester-/Jahreskurse TN Tage Angehörige Sport Kinder & Jugendliche" => 0.0,
+        # rubocop:todo Layout/LineLength
+        "Semester-/Jahreskurse TN Tage Personen mit Behinderung Freizeit Erwachsene & altersdurchmischt" => 0.0,
+        # rubocop:enable Layout/LineLength
+        # rubocop:todo Layout/LineLength
+        "Semester-/Jahreskurse TN Tage Personen mit Behinderung Freizeit Kinder & Jugendliche" => 0.0,
+        # rubocop:enable Layout/LineLength
+        # rubocop:todo Layout/LineLength
+        "Semester-/Jahreskurse TN Tage Personen mit Behinderung Förderung der Autonomie/Bildung" => 0.0,
+        # rubocop:enable Layout/LineLength
+        # rubocop:todo Layout/LineLength
+        "Semester-/Jahreskurse TN Tage Personen mit Behinderung Sport Erwachsene & altersdurchmischt" => 0.0,
+        # rubocop:enable Layout/LineLength
+        "Semester-/Jahreskurse TN Tage Personen mit Behinderung Sport Kinder & Jugendliche" => 0.0,
+        "Semester-/Jahreskurse TN Tage Total Freizeit Erwachsene & altersdurchmischt" => 0.0,
+        "Semester-/Jahreskurse TN Tage Total Freizeit Kinder & Jugendliche" => 0.0,
+        "Semester-/Jahreskurse TN Tage Total Förderung der Autonomie/Bildung" => 0.0,
+        "Semester-/Jahreskurse TN Tage Total Sport Erwachsene & altersdurchmischt" => 0.0,
+        "Semester-/Jahreskurse TN Tage Total Sport Kinder & Jugendliche" => 0.0,
+        # rubocop:todo Layout/LineLength
+        "Semester-/Jahreskurse TN Tage nicht Bezugsberechtigte Freizeit Erwachsene & altersdurchmischt" => 0.0,
+        # rubocop:enable Layout/LineLength
+        # rubocop:todo Layout/LineLength
+        "Semester-/Jahreskurse TN Tage nicht Bezugsberechtigte Freizeit Kinder & Jugendliche" => 0.0,
+        # rubocop:enable Layout/LineLength
+        # rubocop:todo Layout/LineLength
+        "Semester-/Jahreskurse TN Tage nicht Bezugsberechtigte Förderung der Autonomie/Bildung" => 0.0,
+        # rubocop:enable Layout/LineLength
+        # rubocop:todo Layout/LineLength
+        "Semester-/Jahreskurse TN Tage nicht Bezugsberechtigte Sport Erwachsene & altersdurchmischt" => 0.0,
+        # rubocop:enable Layout/LineLength
+        "Semester-/Jahreskurse TN Tage nicht Bezugsberechtigte Sport Kinder & Jugendliche" => 0.0,
+        "Semester-/Jahreskurse Total Vollkosten Freizeit Erwachsene & altersdurchmischt" => 0.0,
+        "Semester-/Jahreskurse Total Vollkosten Freizeit Kinder & Jugendliche" => 0.0,
+        "Semester-/Jahreskurse Total Vollkosten Förderung der Autonomie/Bildung" => 0.0,
+        "Semester-/Jahreskurse Total Vollkosten Sport Erwachsene & altersdurchmischt" => 0.0,
+        "Semester-/Jahreskurse Total Vollkosten Sport Kinder & Jugendliche" => 0.0,
+        "Stunden Angestellte: Grundlagenarbeit Kurse" => 0,
+        "Stunden Angestellte: Grundlagenarbeit Treffpunkte" => 0,
+        "Stunden Angestellte: Grundlagenarbeit Medien & Publikationen" => 0,
+        "Stunden Angestellte: Medien & Publikationen" => 0,
+        "Stunden Angestellte: Sozialberatung" => 0,
+        "Stunden Ehrenamtliche mit Leistungsausweis: Grundlagenarbeit Kurse" => 0,
+        "Stunden Ehrenamtliche mit Leistungsausweis: Grundlagenarbeit Treffpunkte" => 0,
+        "Stunden Ehrenamtliche mit Leistungsausweis: Grundlagenarbeit Medien & Publikationen" => 0,
+        "Stunden Ehrenamtliche mit Leistungsausweis: Medien & Publikationen" => 0,
+        "Stunden Ehrenamtliche mit Leistungsausweis: Sozialberatung" => 0,
+        "Stunden Ehrenamtliche ohne Leistungsausweis: Sozialberatung" => 0,
+        "Tageskurse Anzahl Kurse Freizeit Erwachsene & altersdurchmischt" => 0,
+        "Tageskurse Anzahl Kurse Freizeit Kinder & Jugendliche" => 0,
+        "Tageskurse Anzahl Kurse Förderung der Autonomie/Bildung" => 0,
+        "Tageskurse Anzahl Kurse Sport Erwachsene & altersdurchmischt" => 0,
+        "Tageskurse Anzahl Kurse Sport Kinder & Jugendliche" => 0,
+        "Tageskurse TN Tage Angehörige Freizeit Erwachsene & altersdurchmischt" => 0.0,
+        "Tageskurse TN Tage Angehörige Freizeit Kinder & Jugendliche" => 0.0,
+        "Tageskurse TN Tage Angehörige Förderung der Autonomie/Bildung" => 0.0,
+        "Tageskurse TN Tage Angehörige Sport Erwachsene & altersdurchmischt" => 0.0,
+        "Tageskurse TN Tage Angehörige Sport Kinder & Jugendliche" => 0.0,
+        # rubocop:todo Layout/LineLength
+        "Tageskurse TN Tage Personen mit Behinderung Freizeit Erwachsene & altersdurchmischt" => 0.0,
+        # rubocop:enable Layout/LineLength
+        "Tageskurse TN Tage Personen mit Behinderung Freizeit Kinder & Jugendliche" => 0.0,
+        "Tageskurse TN Tage Personen mit Behinderung Förderung der Autonomie/Bildung" => 0.0,
+        "Tageskurse TN Tage Personen mit Behinderung Sport Erwachsene & altersdurchmischt" => 0.0,
+        "Tageskurse TN Tage Personen mit Behinderung Sport Kinder & Jugendliche" => 0.0,
+        "Tageskurse TN Tage Total Freizeit Erwachsene & altersdurchmischt" => 0.0,
+        "Tageskurse TN Tage Total Freizeit Kinder & Jugendliche" => 0.0,
+        "Tageskurse TN Tage Total Förderung der Autonomie/Bildung" => 0.0,
+        "Tageskurse TN Tage Total Sport Erwachsene & altersdurchmischt" => 0.0,
+        "Tageskurse TN Tage Total Sport Kinder & Jugendliche" => 0.0,
+        "Tageskurse TN Tage nicht Bezugsberechtigte Freizeit Erwachsene & altersdurchmischt" => 0.0,
+        "Tageskurse TN Tage nicht Bezugsberechtigte Freizeit Kinder & Jugendliche" => 0.0,
+        "Tageskurse TN Tage nicht Bezugsberechtigte Förderung der Autonomie/Bildung" => 0.0,
+        "Tageskurse TN Tage nicht Bezugsberechtigte Sport Erwachsene & altersdurchmischt" => 0.0,
+        "Tageskurse TN Tage nicht Bezugsberechtigte Sport Kinder & Jugendliche" => 0.0,
+        "Tageskurse Total Vollkosten Freizeit Erwachsene & altersdurchmischt" => 0.0,
+        "Tageskurse Total Vollkosten Freizeit Kinder & Jugendliche" => 0.0,
+        "Tageskurse Total Vollkosten Förderung der Autonomie/Bildung" => 0.0,
+        "Tageskurse Total Vollkosten Sport Erwachsene & altersdurchmischt" => 0.0,
+        "Tageskurse Total Vollkosten Sport Kinder & Jugendliche" => 0.0,
+        "Totaler Aufwand gemäss FIBU" => 0.0,
+        "Treffpunkte Anzahl Kurse Treffpunkt" => 0,
+        "Treffpunkte Betreuungsstunden Total Treffpunkt" => 0.0,
+        "Treffpunkte TN Tage Angehörige Treffpunkt" => 0.0,
+        "Treffpunkte TN Tage Personen mit Behinderung Treffpunkt" => 0.0,
+        "Treffpunkte TN Tage Total Treffpunkt" => 0.0,
+        "Treffpunkte TN Tage nicht Bezugsberechtigte Treffpunkt" => 0.0,
+        "Treffpunkte Total Vollkosten Treffpunkt" => 0.0,
+        "VID" => nil,
+        "VZÄ angestellte Mitarbeiter (Art. 74)" => 0.0,
+        "VZÄ angestellte Mitarbeiter (ganze Organisation)" => 0.0,
+        "VZÄ ehrenamtliche Mitarbeiter (Art. 74)" => 0.0,
+        "VZÄ ehrenamtliche Mitarbeiter (ganze Organisation)" => 0.0,
+        "VZÄ ehrenamtliche Mitarbeiter mit Leistungsausweis (Art. 74)" => 0.0,
+        "Vollkosten nach Umlagen Betrieb Art. 74" => 0.0
+      }
+    end
+
+    it "for insieme Schweiz" do
+      expect(data.first).to include(empty_row.merge({
+        "Vollständiger Name" => "insieme Schweiz",
+        "Kanton" => nil,
+        "VID" => nil,
+        "BSV Nummer" => 2343,
+
+        "Geschlüsseltes Kapitalsubstrat nach Art. 74" => -200_000.0,
+        "Faktor Kapitalsubstrat" => 0.0,
+        "Totaler Aufwand gemäss FIBU" => 0.0,
+        "Vollkosten nach Umlagen Betrieb Art. 74" => 0.0,
+        "IV-Beitrag" => 0.0,
+        "Deckungsbeitrag 4" => 0.0,
+        "IV-Finanzierungsgrad #{year}" => 0.0
+      }))
+    end
+
+    it "for Freiburg" do
+      expect(data.third).to include(empty_row.merge({
+        "Vollständiger Name" => "Freiburg",
+        "Kanton" => "Freiburg",
+        "VID" => nil,
+        "BSV Nummer" => 12607,
+
+        "Blockkurse Anzahl Kurse Sport Kinder & Jugendliche" => 1,
+        "Blockkurse TN Tage Angehörige Sport Kinder & Jugendliche" => 0.0,
+        "Blockkurse TN Tage Personen mit Behinderung Sport Kinder & Jugendliche" => 1545.0,
+        "Blockkurse TN Tage Total Sport Kinder & Jugendliche" => 1545.0,
+        "Blockkurse TN Tage nicht Bezugsberechtigte Sport Kinder & Jugendliche" => 0.0,
+        "Blockkurse Total Vollkosten Sport Kinder & Jugendliche" => 0.0,
+
+        "LUFEB Stunden Angestellte: Themenspezifische Grundlagenarbeit" => 12,
+        # rubocop:todo Layout/LineLength
+        "LUFEB Stunden Ehrenamtliche mit Leistungsausweis: Allgemeine Medien & Öffentlichkeitsarbeit" => 21,
+        # rubocop:enable Layout/LineLength
+        "LUFEB Stunden Ehrenamtliche ohne Leistungsausweis (Total)" => 0,
+
+        "Tageskurse Anzahl Kurse Sport Kinder & Jugendliche" => 2,
+        "Tageskurse TN Tage Angehörige Sport Kinder & Jugendliche" => 0.0,
+        "Tageskurse TN Tage Personen mit Behinderung Sport Kinder & Jugendliche" => 8500.0,
+        "Tageskurse TN Tage Total Sport Kinder & Jugendliche" => 10164.0,
+        "Tageskurse TN Tage nicht Bezugsberechtigte Sport Kinder & Jugendliche" => 1664.0,
+        "Tageskurse Total Vollkosten Sport Kinder & Jugendliche" => 1100.0,
+
+        "Treffpunkte Anzahl Kurse Treffpunkt" => 1,
+        "Treffpunkte Betreuungsstunden Total Treffpunkt" => 36.0, # 18 Stunden * 2 BetreuerInnen
+
+        "VZÄ angestellte Mitarbeiter (Art. 74)" => 1.6,
+        "VZÄ angestellte Mitarbeiter (ganze Organisation)" => 2.0,
+        # 21 Stunden für LUFEB / 1900 BSV-Stunden = 0.01105
+        "VZÄ ehrenamtliche Mitarbeiter (Art. 74)" => (21.0 / 1900).round(5),
+        "VZÄ ehrenamtliche Mitarbeiter (ganze Organisation)" => (21.0 / 1900).round(5),
+        "VZÄ ehrenamtliche Mitarbeiter mit Leistungsausweis (Art. 74)" => (21.0 / 1900).round(5),
+
+        "Geschlüsseltes Kapitalsubstrat nach Art. 74" => -201100.0,
+        "Faktor Kapitalsubstrat" => -182.81818,
+        "Totaler Aufwand gemäss FIBU" => 0.0,
+        "Vollkosten nach Umlagen Betrieb Art. 74" => 1100.0,
+        "IV-Beitrag" => 0.0,
+        "Deckungsbeitrag 4" => -1100.0,
+        "IV-Finanzierungsgrad #{year}" => 0.0
+      }))
+    end
+
+    it "for Kanton Bern" do
+      # 30 Stunden für LUFEB / 1900 BSV-Stunden
+      expect(data.fourth).to include(empty_row.merge({
+        "Vollständiger Name" => "Kanton Bern",
+        "Kanton" => "Bern",
+        "BSV Nummer" => 2024,
+        "VID" => nil,
+
+        "Blockkurse Anzahl Kurse Sport Kinder & Jugendliche" => 4,
+        "Blockkurse TN Tage Angehörige Sport Kinder & Jugendliche" => 1111.0,
+        "Blockkurse TN Tage Personen mit Behinderung Sport Kinder & Jugendliche" => 6400.0,
+        "Blockkurse TN Tage Total Sport Kinder & Jugendliche" => 15961.0,
+        "Blockkurse TN Tage nicht Bezugsberechtigte Sport Kinder & Jugendliche" => 8450.0,
+        "Blockkurse Total Vollkosten Sport Kinder & Jugendliche" => 2100.0,
+
+        "Semester-/Jahreskurse Anzahl Kurse Sport Kinder & Jugendliche" => 1,
+        "Semester-/Jahreskurse TN Tage Angehörige Sport Kinder & Jugendliche" => 0.0,
+        # rubocop:todo Layout/LineLength
+        "Semester-/Jahreskurse TN Tage Personen mit Behinderung Sport Kinder & Jugendliche" => 1428.0,
+        # rubocop:enable Layout/LineLength
+        "Semester-/Jahreskurse TN Tage Total Sport Kinder & Jugendliche" => 1428.0,
+        "Semester-/Jahreskurse TN Tage nicht Bezugsberechtigte Sport Kinder & Jugendliche" => 0.0,
+        "Semester-/Jahreskurse Total Vollkosten Sport Kinder & Jugendliche" => 410.0,
+
+        "Tageskurse Anzahl Kurse Sport Kinder & Jugendliche" => 0,
+        "Tageskurse TN Tage Angehörige Sport Kinder & Jugendliche" => 0.0,
+        "Tageskurse TN Tage Personen mit Behinderung Sport Kinder & Jugendliche" => 0.0,
+        "Tageskurse TN Tage Total Sport Kinder & Jugendliche" => 0.0,
+        "Tageskurse TN Tage nicht Bezugsberechtigte Sport Kinder & Jugendliche" => 0.0,
+        "Tageskurse Total Vollkosten Sport Kinder & Jugendliche" => 0.0,
+
+        "LUFEB Stunden Angestellte: Allgemeine Medien & Öffentlichkeitsarbeit" => 0,
+        "LUFEB Stunden Angestellte: Förderung der Selbsthilfe" => 0,
+        "LUFEB Stunden Angestellte: Grundlagenarbeit zu LUFEB" => 0,
+        "LUFEB Stunden Angestellte: Themenspezifische Grundlagenarbeit" => 0,
+
+        # rubocop:todo Layout/LineLength
+        "LUFEB Stunden Ehrenamtliche mit Leistungsausweis: Allgemeine Medien & Öffentlichkeitsarbeit" => 0,
+        # rubocop:enable Layout/LineLength
+        "LUFEB Stunden Ehrenamtliche mit Leistungsausweis: Förderung der Selbsthilfe" => 0,
+        "LUFEB Stunden Ehrenamtliche mit Leistungsausweis: Grundlagenarbeit zu LUFEB" => 0,
+        "LUFEB Stunden Ehrenamtliche mit Leistungsausweis: Themenspezifische Grundlagenarbeit" => 0,
+
+        "LUFEB Stunden Ehrenamtliche ohne Leistungsausweis (Total)" => 30,
+        "Stunden Ehrenamtliche ohne Leistungsausweis: Sozialberatung" => 0,
+
+        "Stunden Angestellte: Grundlagenarbeit Kurse" => 8,
+        "Stunden Angestellte: Grundlagenarbeit Treffpunkte" => 0,
+        "Stunden Angestellte: Grundlagenarbeit Medien & Publikationen" => 0,
+        "Stunden Angestellte: Medien & Publikationen" => 0,
+        "Stunden Angestellte: Sozialberatung" => 9,
+        "Stunden Ehrenamtliche mit Leistungsausweis: Grundlagenarbeit Kurse" => 0,
+        "Stunden Ehrenamtliche mit Leistungsausweis: Grundlagenarbeit Treffpunkte" => 21,
+        "Stunden Ehrenamtliche mit Leistungsausweis: Grundlagenarbeit Medien & Publikationen" => 0,
+        "Stunden Ehrenamtliche mit Leistungsausweis: Medien & Publikationen" => 0,
+        "Stunden Ehrenamtliche mit Leistungsausweis: Sozialberatung" => 0,
+
+        "Treffpunkte Anzahl Kurse Treffpunkt" => 0,
+
+        "VZÄ angestellte Mitarbeiter (Art. 74)" => 0.25,
+        "VZÄ angestellte Mitarbeiter (ganze Organisation)" => 0.25,
+        "VZÄ ehrenamtliche Mitarbeiter (Art. 74)" => 0.02684,
+        "VZÄ ehrenamtliche Mitarbeiter (ganze Organisation)" => 0.02684,
+        "VZÄ ehrenamtliche Mitarbeiter mit Leistungsausweis (Art. 74)" => 0.01105,
+
+        "Geschlüsseltes Kapitalsubstrat nach Art. 74" => 10048000.0,
+        "Faktor Kapitalsubstrat" => 4901.46341,
+        "Totaler Aufwand gemäss FIBU" => 100.0,
+        "IV-Beitrag" => 20.0,
+        "Vollkosten nach Umlagen Betrieb Art. 74" => 2050.0,
+        "Deckungsbeitrag 4" => -2000.0,
+        "IV-Finanzierungsgrad #{year}" => 100.0
+      }))
+    end
+
+    it "for Biel-Seeland" do
+      expect(data.second).to include(empty_row.merge({
+        "Vollständiger Name" => "Biel-Seeland",
+        "Kanton" => "Bern",
+        "BSV Nummer" => 3115,
+
+        "Geschlüsseltes Kapitalsubstrat nach Art. 74" => -200_000.0,
+        "Faktor Kapitalsubstrat" => 0.0,
+        "Totaler Aufwand gemäss FIBU" => 0.0,
+        "Vollkosten nach Umlagen Betrieb Art. 74" => 0.0,
+        "IV-Beitrag" => 0.0,
+        "Deckungsbeitrag 4" => 0.0,
+        "IV-Finanzierungsgrad #{year}" => 0.0
+      }))
+    end
+  end
+
+  private
+
+  def create_course(year, group_key, leistungskategorie, kategorie, attrs)
+    fachkonzept = (leistungskategorie == "tp") ? "treffpunkt" : "sport_jugend"
+
+    event = Fabricate(:course, leistungskategorie: leistungskategorie, fachkonzept: fachkonzept)
+    event.update(groups: [groups(group_key)])
+    event.dates.create!(start_at: Time.zone.local(year, 0o5, 11))
+
+    r = Event::CourseRecord.create!(attrs.merge(event_id: event.id, year: year))
+    r.update_column(:zugeteilte_kategorie, kategorie)
+  end
+end

--- a/spec/domain/fp2024/export/tabular/statistics/group_figures_spec.rb
+++ b/spec/domain/fp2024/export/tabular/statistics/group_figures_spec.rb
@@ -432,7 +432,7 @@ describe Fp2024::Export::Tabular::Statistics::GroupFigures do
     end
 
     it "for Freiburg" do
-      expect(data.third).to include(empty_row.merge({
+      expect(data.second).to include(empty_row.merge({
         "Vollständiger Name" => "Freiburg",
         "Kanton" => "Freiburg",
         "VID" => nil,
@@ -480,7 +480,7 @@ describe Fp2024::Export::Tabular::Statistics::GroupFigures do
 
     it "for Kanton Bern" do
       # 30 Stunden für LUFEB / 1900 BSV-Stunden
-      expect(data.fourth).to include(empty_row.merge({
+      expect(data.third).to include(empty_row.merge({
         "Vollständiger Name" => "Kanton Bern",
         "Kanton" => "Bern",
         "BSV Nummer" => 2024,
@@ -554,7 +554,7 @@ describe Fp2024::Export::Tabular::Statistics::GroupFigures do
     end
 
     it "for Biel-Seeland" do
-      expect(data.second).to include(empty_row.merge({
+      expect(data.fourth).to include(empty_row.merge({
         "Vollständiger Name" => "Biel-Seeland",
         "Kanton" => "Bern",
         "BSV Nummer" => 3115,

--- a/spec/domain/fp2024/export/tabular/time_records/list_spec.rb
+++ b/spec/domain/fp2024/export/tabular/time_records/list_spec.rb
@@ -1,0 +1,86 @@
+#  Copyright (c) 2024, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require "spec_helper"
+
+describe "Export::Tabular::TimeRecords::List" do
+  let(:year) { 2024 }
+  let(:group) { groups(:be) }
+
+  context "without records" do
+    it "contains correct headers" do
+      labels = fp_class("Export::Tabular::TimeRecords::List")
+        .new(TimeRecord.where(group_id: group.id, year: year))
+        .labels
+      expect(labels).to eq [nil,
+        "Zeiterfassung Angestellte",
+        "Zeiterfassung Ehrenamtliche mit Leistungsnachweis",
+        "Zeiterfassung Ehrenamtliche ohne Leistungsnachweis"]
+    end
+
+    it "contains no data" do
+      export.each do |row|
+        expect(row[1..]).to eq([nil, nil, nil])
+      end
+    end
+  end
+
+  context "with records" do
+    before do
+      TimeRecord::EmployeeTime.create!(
+        group: group, year: year, apps: 200, website: 330, blockkurse: 300, kurse_grundlagen: 42,
+        nicht_art_74_leistungen: 50,
+        employee_pensum_attributes: {paragraph_74: 1.5, not_paragraph_74: 0.5}
+      )
+      TimeRecord::VolunteerWithVerificationTime.create!(
+        # rubocop:todo Layout/LineLength
+        group: group, year: year, lufeb_grundlagen: 100, blockkurse: 400, verwaltung: 88, treffpunkte_grundlagen: 43,
+        # rubocop:enable Layout/LineLength
+        nicht_art_74_leistungen: 50
+      )
+      TimeRecord::VolunteerWithoutVerificationTime.create!(
+        group: group, year: year, total_lufeb_general: 300, tageskurse: 55, treffpunkte: 37,
+        nicht_art_74_leistungen: 50
+      )
+    end
+
+    it "contains all data" do
+      data = [nil] + export.each { |row|
+        row.collect! { |v|
+       v.is_a?(BigDecimal) ? v.to_f.round(2) : v # rubocop:todo Layout/IndentationWidth
+        }
+      }
+      expect(data[1]).to eq(["Art. 74 betreffend in 100% Stellen", 1.5, nil, nil])
+      expect(data[2]).to eq(["Art. 74 nicht betreffend in 100% Stellen", 0.5, nil, nil])
+      expect(data[3]).to eq(["Total", 2.0, nil, nil])
+      expect(data[4]).to eq(["Grundlagenarbeit zu LUFEB", nil, 100.0, nil])
+      expect(data[5]).to eq(["Information / Beratung von Organisationen und Einzelpersonen", nil,
+        nil, nil])
+
+      expect(data[13]).to eq(["Allgemeine Medien- und Öffentlichkeitsarbeit", 0, 0, 300])
+
+      expect(data[20]).to eq(["Grundlagenarbeit zu Medien & Publikationen", nil, nil, nil])
+      expect(data[21]).to eq(["Website", 330.0, nil, nil])
+      expect(data[26]).to eq(["Applikationen", 200.0, nil, nil])
+      expect(data[27]).to eq(["Medien & Publikationen", 530.0, 0.0, nil])
+
+      expect(data[28]).to eq(["Grundlagenarbeit zu Kursen", 42, nil, nil])
+      expect(data[29]).to eq(["Blockkurse", 300.0, 400.0, nil])
+      expect(data[30]).to eq(["Tageskurse", nil, nil, 55.0])
+      expect(data[32]).to eq(["Grundlagenarbeit zu Treffpunkten", nil, 43, nil])
+      expect(data[33]).to eq(["Treffpunkte", nil, nil, 37.0])
+
+      expect(data[44]).to eq(["Total", 922.0, 681.0, 442.0])
+      expect(data[45]).to eq(["Ausgedrückt in-100% Stellen", 0.49, 0.36, 0.23])
+    end
+  end
+
+  def export
+    fp_class("Export::Tabular::TimeRecords::List")
+      .new(TimeRecord.where(group_id: group.id, year: year))
+      .data_rows
+      .to_a
+  end
+end

--- a/spec/domain/fp2024/export/tabular/time_records/lufeb_pro_verein_spec.rb
+++ b/spec/domain/fp2024/export/tabular/time_records/lufeb_pro_verein_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2021, Insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require "spec_helper"
+
+describe Fp2024::Export::Tabular::TimeRecords::LufebProVerein do
+  include Featureperioden::Domain
+
+  let(:year) { 2024 }
+  subject { described_class.new(data) }
+
+  let(:data) do
+    lpv = Fp2024::TimeRecord::LufebProVerein.new(year)
+    verein_ids = lpv.vereine.map(&:id)
+
+    lpv.instance_variable_set(:@lufeb_data, {
+      verein_ids[0] => Fp2024::TimeRecord::LufebProVerein::Data.new(1, 2, 3, 4, 5),
+      verein_ids[1] => Fp2024::TimeRecord::LufebProVerein::Data.new(2, 4, 6, 8, 9),
+      verein_ids[2] => Fp2024::TimeRecord::LufebProVerein::Data.new(Array.new(5) { 0 }),
+      verein_ids[3] => Fp2024::TimeRecord::LufebProVerein::Data.new(Array.new(5) { 0 })
+    })
+
+    lpv
+  end
+
+  it "has labels" do
+    expected = ["Gruppe/Feldname", ""]
+
+    expect(subject.labels).to match_array expected
+    expect(subject.labels).to eq expected
+  end
+
+  it "has all the calculated values" do
+    rows = subject.data_rows.take(10)
+
+    expect(rows[0]).to be_all nil
+    expect(rows[1]).to eq ["insieme Schweiz", nil]
+    expect(rows[2]).to eq ["Allgemeine Medien & Öffentlichkeitsarbeit", 1]
+    expect(rows[3]).to eq ["Themenspezifische Grundlagenarbeit", 11]
+    expect(rows[4]).to eq ["Förderung der Selbsthilfe", 3]
+    expect(rows[5]).to be_all nil
+    expect(rows[6]).to eq ["Kanton Bern", nil]
+    expect(rows[7]).to eq ["Allgemeine Medien & Öffentlichkeitsarbeit", 2]
+    expect(rows[8]).to eq ["Themenspezifische Grundlagenarbeit", 21]
+    expect(rows[9]).to eq ["Förderung der Selbsthilfe", 6]
+  end
+
+  context "adds grundlagenarbeit to specific, it" do
+    let(:group) { groups(:seeland) }
+
+    subject(:lufeb_verein_data) do
+      # Struct.new(:general, :specific, :promoting, :lufeb_grundlagen, :kurse_grundlagen)
+      fp_class("TimeRecord::LufebProVerein::Data").new(nil, 30, nil, 10, 20)
+    end
+
+    it "takes data from the lufeb-for-verein-data" do
+      expect(lufeb_verein_data.specific.to_f).to eq 30
+      expect(lufeb_verein_data.lufeb_grundlagen.to_f).to eq 10
+      expect(lufeb_verein_data.kurse_grundlagen.to_f).to eq 20
+    end
+
+    it "matches the actual implementation result" do
+      # collaborators
+      stats = double("LUFEB pro Verein-stats")
+
+      # return-values from collbarators
+      allow(stats).to receive(:year).and_return(year) # from let above
+      expect(stats).to receive(:lufeb_data_for).with(group.id).and_return(lufeb_verein_data)
+
+      # execute
+      result = described_class.new(stats)
+        .send(:specific_with_grundlagen, group)
+
+      expect(result).to be_within(0.001).of(60)
+    end
+  end
+end

--- a/spec/domain/fp2024/export/tabular/time_records/organisations_daten_spec.rb
+++ b/spec/domain/fp2024/export/tabular/time_records/organisations_daten_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2021-2023, Insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require "spec_helper"
+
+describe Fp2024::Export::Tabular::TimeRecords::OrganisationsDaten do
+  let(:year) { 2024 }
+  subject { described_class.new(data) }
+
+  let(:data) do
+    od = fp_class("TimeRecord::OrganisationsDaten").new(year)
+    verein_ids = od.vereine.map(&:id)
+
+    od.instance_variable_set(:@data_for, {
+      verein_ids[0] => Fp2024::TimeRecord::OrganisationsDaten::Data.new(10, 5, 20, 8, 4),
+      verein_ids[1] => Fp2024::TimeRecord::OrganisationsDaten::Data.new(*Array.new(5) { 0 }),
+      verein_ids[2] => Fp2024::TimeRecord::OrganisationsDaten::Data.new(10, 5, 20, 7, 4),
+      verein_ids[3] => Fp2024::TimeRecord::OrganisationsDaten::Data.new(*Array.new(5) { 0 })
+    })
+
+    od
+  end
+
+  it "has labels" do
+    expected = ["Gruppe/Feldname", ""]
+
+    expect(subject.labels).to match_array expected
+    expect(subject.labels).to eq expected
+  end
+
+  it "has all the calculated values" do
+    rows = subject.data_rows.take(18)
+
+    expect(rows[0]).to be_all nil
+    # all values
+    expect(rows[1]).to eq ["insieme Schweiz", nil]
+    expect(rows[2]).to eq ["FTE Angestellte MA insgesamt", 10]
+    expect(rows[3]).to eq ["FTE Angestellte MA Betrieb Art. 74 IVG", 5]
+    expect(rows[4]).to eq ["FTE Freiwillig und ehrenamtlich Mitarbeitende insgesamt", 28]
+    expect(rows[5]).to eq [
+      "FTE Freiwillig und ehrenamtlich Mitarbeitende des Betriebes Art. 74 IVG", 4
+    ]
+    expect(rows[6]).to be_all nil
+    # no values
+    expect(rows[7]).to eq ["Kanton Bern", nil]
+    expect(rows[8]).to eq ["FTE Angestellte MA insgesamt", 0]
+    expect(rows[9]).to eq ["FTE Angestellte MA Betrieb Art. 74 IVG", 0]
+    expect(rows[10]).to eq ["FTE Freiwillig und ehrenamtlich Mitarbeitende insgesamt", 0]
+    expect(rows[11]).to eq [
+      "FTE Freiwillig und ehrenamtlich Mitarbeitende des Betriebes Art. 74 IVG", 0
+    ]
+    expect(rows[12]).to be_all nil
+    # no honorar-ausgaben
+    expect(rows[13]).to eq ["Biel-Seeland", nil]
+    expect(rows[14]).to eq ["FTE Angestellte MA insgesamt", 10]
+    expect(rows[15]).to eq ["FTE Angestellte MA Betrieb Art. 74 IVG", 5]
+    expect(rows[16]).to eq ["FTE Freiwillig und ehrenamtlich Mitarbeitende insgesamt", 27]
+    expect(rows[17]).to eq [
+      "FTE Freiwillig und ehrenamtlich Mitarbeitende des Betriebes Art. 74 IVG", 4
+    ]
+  end
+end

--- a/spec/domain/fp2024/export/tabular/time_records/vereinsliste_spec.rb
+++ b/spec/domain/fp2024/export/tabular/time_records/vereinsliste_spec.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require "spec_helper"
+
+describe Fp2024::Export::Tabular::TimeRecords::Vereinsliste do
+  let(:year) { 2024 }
+  let(:type) { TimeRecord::EmployeeTime.sti_name }
+
+  context "without records" do
+    context "for employee time" do
+      it "contains correct headers" do
+        labels = described_class.new(fp_class("TimeRecord::Vereinsliste").new(year, type)).labels
+        expected_labels = [
+          "Gruppe",
+          "Grundlagenarbeit zu LUFEB",
+          "Information / Beratung von Organisationen und Einzelpersonen",
+          "Unterstützung von Menschen mit Behinderungen in Leitorganen",
+          "Akquisition von Freiwilligen",
+          "Förderung der Selbsthilfe",
+          # rubocop:todo Layout/LineLength
+          "Auskünfte an die Öffentlichkeit, Menschen mit Behinderung, Angehörige, Fachpersonen, Medien",
+          # rubocop:enable Layout/LineLength
+          "Vorträge / Referate",
+          "Zusammenarbeit mit Medien",
+          "Sensibilisierungs- und Entstigmatisierungsarbeiten resp. -veranstaltungen",
+          "Allgemeine Medien- und Öffentlichkeitsarbeit",
+          "Grundlagenarbeit (Arbeitsinstrumente, Konzepte, Studien, Grundlagenpapiere)",
+          "Mitgliedschaft / Mitarbeit in Gremien",
+          "Mitarbeit bei Vernehmlassungen",
+          "Projekte Art. 74 (Vorbereitung und Durchführung)",
+          "Themenspezifische Grundlagenarbeit / Projekte",
+          "Total LUFEB-Leistungen",
+          "Grundlagenarbeit zu Medien & Publikationen",
+          "Website",
+          "Rundbriefe, Broschüren, Merkblätter",
+          "Videos",
+          "Soziale Medien",
+          "Standardisierte Beratungsmodule",
+          "Applikationen",
+          "Medien & Publikationen",
+          "Grundlagenarbeit zu Kursen",
+          "Blockkurse",
+          "Tageskurse",
+          "Semester-/Jahreskurse",
+          "Grundlagenarbeit zu Treffpunkten",
+          "Treffpunkte",
+          "Total Kurse & Treffpunkte",
+          "Sozialberatung (inkl. Grundlagenarbeit)",
+          "Mittelbeschaffung",
+          "Vereinsführung und Verwaltung",
+          "Total übrige Leistungen",
+          "Total Art. 74 betreffend",
+          "Total Art. 74 nicht betreffend",
+          "Total"
+        ]
+        expect(labels).to match_array expected_labels
+        expect(labels).to eq expected_labels
+      end
+    end
+
+    context "for volunteer without verification time" do
+      let(:type) { TimeRecord::VolunteerWithoutVerificationTime.sti_name }
+
+      it "contains correct headers" do
+        labels = described_class.new(fp_class("TimeRecord::Vereinsliste").new(year, type)).labels
+        expected_labels = [
+          "Gruppe",
+          "Grundlagenarbeit zu LUFEB",
+          "Förderung der Selbsthilfe",
+          "Allgemeine Medien- und Öffentlichkeitsarbeit",
+          "Themenspezifische Grundlagenarbeit / Projekte",
+          "Total LUFEB-Leistungen",
+          "Medien & Publikationen",
+          "Grundlagenarbeit zu Kursen",
+          "Blockkurse",
+          "Tageskurse",
+          "Semester-/Jahreskurse",
+          "Grundlagenarbeit zu Treffpunkten",
+          "Treffpunkte",
+          "Total Kurse & Treffpunkte",
+          "Sozialberatung (inkl. Grundlagenarbeit)",
+          "Mittelbeschaffung",
+          "Vereinsführung und Verwaltung",
+          "Total übrige Leistungen",
+          "Total Art. 74 betreffend",
+          "Total Art. 74 nicht betreffend",
+          "Total"
+        ]
+        expect(labels).to match_array expected_labels
+        expect(labels).to eq expected_labels
+      end
+    end
+
+    it "contains no data" do
+      rows = export
+      expect(rows[0]).to match_array ["insieme Schweiz",
+        nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+        nil, nil, nil, nil, nil,
+        nil, nil, nil, nil, nil, nil, nil,
+        nil, nil, nil, nil, nil, nil, nil,
+        nil, nil, nil, nil,
+        nil, nil, nil]
+    end
+  end
+
+  context "with records" do
+    before do
+      TimeRecord::EmployeeTime.create!(
+        # rubocop:todo Layout/LineLength
+        group: groups(:be), year: year, eigene_zeitschriften: 200, eigene_webseite: 330, blockkurse: 300,
+        # rubocop:enable Layout/LineLength
+        nicht_art_74_leistungen: 50,
+        employee_pensum_attributes: {paragraph_74: 1.5, not_paragraph_74: 0.5}
+      )
+      TimeRecord::EmployeeTime.create!(
+        # rubocop:todo Layout/LineLength
+        group: groups(:fr), year: year, eigene_zeitschriften: 100, eigene_webseite: 230, blockkurse: 200,
+        # rubocop:enable Layout/LineLength
+        nicht_art_74_leistungen: 0o0
+      )
+      TimeRecord::VolunteerWithVerificationTime.create!(
+        group: groups(:be), year: year, kontakte_medien: 100, blockkurse: 400, verwaltung: 88,
+        nicht_art_74_leistungen: 50
+      )
+      TimeRecord::VolunteerWithoutVerificationTime.create!(
+        group: groups(:be), year: year, total_lufeb_general: 300, tageskurse: 55,
+        nicht_art_74_leistungen: 50
+      )
+    end
+
+    context "for employee time" do
+      it "contains all data" do
+        data = export
+        expect(data[3]).to eq(["Kanton Bern",
+          nil, nil, nil, nil, 0,
+          nil, nil, nil, nil, 0,
+          nil, nil, nil, nil, 0, 0,
+          nil, nil, nil, nil, nil, nil, nil, 0,
+          nil, 300,
+          nil, nil, nil, nil, 300,
+          nil,
+          nil, nil, 0,
+          300, 50,
+          350])
+      end
+
+      it "includes externe organisation" do
+        external_group = Group.create!(parent: groups(:dachverein),
+          name: "externa",
+          type: Group::ExterneOrganisation.sti_name)
+        TimeRecord::EmployeeTime.create!(
+          # rubocop:todo Layout/LineLength
+          group: external_group, year: year, eigene_zeitschriften: 42, eigene_webseite: 230, blockkurse: 200,
+          # rubocop:enable Layout/LineLength
+          nicht_art_74_leistungen: 0o0
+        )
+        data = export
+
+        expect(data.last.first).to eq("externa")
+      end
+    end
+
+    context "for volunteer wthout verification time" do
+      let(:type) { TimeRecord::VolunteerWithoutVerificationTime.sti_name }
+
+      let(:labels) {
+        described_class.new(fp_class("TimeRecord::Vereinsliste").new(year, type)).labels
+      }
+      let(:empty_row) { labels.zip(Array(labels.size)).to_h }
+
+      it "contains all data" do
+        data = export
+        expect(labels.zip(data[3]).to_h).to eq empty_row.merge({
+          "Gruppe" => "Kanton Bern",
+
+          "Allgemeine Medien- und Öffentlichkeitsarbeit" => 300,
+          "Total LUFEB-Leistungen" => 300,
+
+          "Tageskurse" => 55,
+          "Total Kurse & Treffpunkte" => 55,
+
+          "Total übrige Leistungen" => 0,
+          "Total Art. 74 betreffend" => 355,
+          "Total Art. 74 nicht betreffend" => 50,
+
+          "Total" => 405
+        })
+      end
+    end
+  end
+
+  def export
+    exporter = described_class.new(fp_class("TimeRecord::Vereinsliste").new(year, type))
+    exporter.data_rows.to_a
+  end
+end

--- a/spec/domain/fp2024/export/tabular/time_records/vereinsliste_spec.rb
+++ b/spec/domain/fp2024/export/tabular/time_records/vereinsliste_spec.rb
@@ -136,7 +136,7 @@ describe Fp2024::Export::Tabular::TimeRecords::Vereinsliste do
     context "for employee time" do
       it "contains all data" do
         data = export
-        expect(data[3]).to eq(["Kanton Bern",
+        expect(data[2]).to eq(["Kanton Bern",
           nil, nil, nil, nil, 0,
           nil, nil, nil, nil, 0,
           nil, nil, nil, nil, 0, 0,
@@ -175,7 +175,7 @@ describe Fp2024::Export::Tabular::TimeRecords::Vereinsliste do
 
       it "contains all data" do
         data = export
-        expect(labels.zip(data[3]).to_h).to eq empty_row.merge({
+        expect(labels.zip(data[2]).to_h).to eq empty_row.merge({
           "Gruppe" => "Kanton Bern",
 
           "Allgemeine Medien- und Öffentlichkeitsarbeit" => 300,

--- a/spec/domain/fp2024/export/xlsx/events/aggregate_course/detail_list_spec.rb
+++ b/spec/domain/fp2024/export/xlsx/events/aggregate_course/detail_list_spec.rb
@@ -1,0 +1,49 @@
+#  Copyright (c) 2012-2024, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require "spec_helper"
+
+module Fp2024
+  describe Export::Tabular::Events::AggregateCourse::DetailList do
+    let(:courses) { [course1] }
+    let(:course1) do
+      Fabricate(:course, groups: [groups(:be)], motto: "All for one", cost: 1000,
+        application_opening_at: "01.01.2024", application_closing_at: "01.02.2024",
+        maximum_participants: 10, external_applications: false, priorization: false,
+        leistungskategorie: "bk", fachkonzept: "sport_jugend",
+        dates: [Fabricate(:fp2024_date)])
+    end
+
+    it "exports detail events list as xlsx" do
+      expect_any_instance_of(Axlsx::Worksheet)
+        .to receive(:add_row)
+        .exactly(5).times
+        .and_call_original
+
+      expect_any_instance_of(Axlsx::Worksheet)
+        .to receive(:column_widths)
+        .with(*column_widths)
+        .and_call_original
+
+      expect_any_instance_of(::Export::Xlsx::Generator)
+        .to receive(:data_row_height)
+        .with(50)
+        .and_call_original
+
+      Export::Tabular::Events::AggregateCourse::DetailList.xlsx(courses, "test group name", "2024")
+    end
+
+    private
+
+    def column_widths
+      [
+        18, 12.86, 20, 18, 18, 2.57, 2.57, 2.57, 2.57, 2.57, 2.57,
+        2.57, 2.57, 2.57, 2.57, 2.57, 2.57, 2.57, 2.57, 2.57, 2.57, 2.57,
+        2.57, 2.57, 2.57, 2.57, 2.57, 2.57, 2.57, 2.57, 2.57, 2.57, 2.57,
+        2.57, 2.57, 2.57
+      ]
+    end
+  end
+end

--- a/spec/domain/fp2024/export/xlsx/events/aggregate_course/short_list_spec.rb
+++ b/spec/domain/fp2024/export/xlsx/events/aggregate_course/short_list_spec.rb
@@ -1,0 +1,49 @@
+#  Copyright (c) 2012-2024, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require "spec_helper"
+
+module Fp2024
+  describe Export::Tabular::Events::AggregateCourse::ShortList do
+    let(:courses) { [course1] }
+    let(:course1) do
+      Fabricate(:course, groups: [groups(:be)], motto: "All for one", cost: 1000,
+        application_opening_at: "01.01.2024", application_closing_at: "01.02.2024",
+        maximum_participants: 10, external_applications: false, priorization: false,
+        leistungskategorie: "bk", fachkonzept: "sport_jugend",
+        dates: [Fabricate(:fp2024_date)])
+    end
+
+    it "exports short events list as xlsx" do
+      expect_any_instance_of(Axlsx::Worksheet)
+        .to receive(:add_row)
+        .exactly(5).times
+        .and_call_original
+
+      expect_any_instance_of(Axlsx::Worksheet)
+        .to receive(:column_widths)
+        .with(*column_widths)
+        .and_call_original
+
+      expect_any_instance_of(::Export::Xlsx::Generator)
+        .to receive(:data_row_height)
+        .with(50)
+        .and_call_original
+
+      Export::Tabular::Events::AggregateCourse::ShortList.xlsx(courses, "test group name", "2024")
+    end
+
+    private
+
+    def column_widths
+      [
+        18, 12.86, 20, 18, 18, 2.57, 2.57, 2.57, 2.57, 2.57, 2.57,
+        2.57, 2.57, 2.57, 2.57, 2.57, 2.57, 2.57, 2.57, 2.57, 2.57, 2.57,
+        2.57, 2.57, 2.57, 2.57, 2.57, 2.57, 2.57, 2.57, 2.57, 2.57, 2.57,
+        2.57, 2.57, 2.57
+      ]
+    end
+  end
+end

--- a/spec/domain/fp2024/export/xlsx/events/detail_list_spec.rb
+++ b/spec/domain/fp2024/export/xlsx/events/detail_list_spec.rb
@@ -1,0 +1,53 @@
+#  Copyright (c) 2012-2024, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require "spec_helper"
+
+module Fp2024
+  describe Export::Tabular::Events::DetailList do
+    let(:courses) { [course1] }
+    let(:course1) do
+      Fabricate(:course, groups: [groups(:be)], motto: "All for one", cost: 1000,
+        application_opening_at: "01.01.2024", application_closing_at: "01.02.2024",
+        maximum_participants: 10, external_applications: false, priorization: false,
+        leistungskategorie: "bk", fachkonzept: "sport_jugend",
+        dates: [Fabricate(:fp2024_date)])
+    end
+
+    it "exports detail events list as xlsx" do
+      expect_any_instance_of(Axlsx::Worksheet)
+        .to receive(:add_row)
+        .exactly(5).times
+        .and_call_original
+
+      expect_any_instance_of(Axlsx::Worksheet)
+        .to receive(:column_widths)
+        .with(*column_widths)
+        .and_call_original
+
+      expect_any_instance_of(::Export::Xlsx::Generator)
+        .to receive(:data_row_height)
+        .with(130)
+        .and_call_original
+
+      Export::Tabular::Events::DetailList.xlsx(courses, "test group name", "2024")
+    end
+
+    private
+
+    def column_widths
+      # rubocop:todo Layout/LineLength
+      [20, 20, 3.3, 20, 2.57, 7.43, 2.57, 2.57, 2.57, 2.57, 2.57, 2.57, 2.57, 2.57, 2.57, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+        # rubocop:enable Layout/LineLength
+        # rubocop:todo Layout/LineLength
+        20, 5.7, 9.14, 9.14, 2.57, 3.7, 3, 7, 2.57, 2.57, 17.14, 4.29, 3.71, 2.57, 11.57, 3.71, 2.57, 4.29, 4.29, 4.29,
+        # rubocop:enable Layout/LineLength
+        # rubocop:todo Layout/LineLength
+        4.29, 4.29, 4.29, 4.29, 4.29, 6.29, 6.29, 6.29, 2.57, 2.57, 2.57, 2.57, 2.57, 8.14, 8.14, 8.14, 8.14, 8.14,
+        # rubocop:enable Layout/LineLength
+        2.57, 8.14, 9.14, 8.14, 2.54]
+    end
+  end
+end

--- a/spec/domain/fp2024/export/xlsx/events/short_list_spec.rb
+++ b/spec/domain/fp2024/export/xlsx/events/short_list_spec.rb
@@ -1,0 +1,53 @@
+#  Copyright (c) 2012-2017, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require "spec_helper"
+
+module Fp2024
+  describe Export::Tabular::Events::ShortList do
+    let(:courses) { [course1] }
+    let(:course1) do
+      Fabricate(:course, groups: [groups(:be)], motto: "All for one", cost: 1000,
+        application_opening_at: "01.01.2024", application_closing_at: "01.02.2024",
+        maximum_participants: 10, external_applications: false, priorization: false,
+        leistungskategorie: "bk", fachkonzept: "sport_jugend",
+        dates: [Fabricate(:fp2024_date)])
+    end
+
+    it "exports short events list as xlsx" do
+      expect_any_instance_of(Axlsx::Worksheet)
+        .to receive(:add_row)
+        .exactly(5).times
+        .and_call_original
+
+      expect_any_instance_of(Axlsx::Worksheet)
+        .to receive(:column_widths)
+        .with(*column_widths)
+        .and_call_original
+
+      expect_any_instance_of(::Export::Xlsx::Generator)
+        .to receive(:data_row_height)
+        .with(130)
+        .and_call_original
+
+      Export::Tabular::Events::ShortList.xlsx(courses, "test group name", "2024")
+    end
+
+    private
+
+    def column_widths
+      # rubocop:todo Layout/LineLength
+      [20, 20, 3.3, 20, 2.57, 7.43, 2.57, 2.57, 2.57, 2.57, 2.57, 2.57, 2.57, 2.57, 2.57, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+        # rubocop:enable Layout/LineLength
+        # rubocop:todo Layout/LineLength
+        20, 5.7, 9.14, 9.14, 2.57, 3.7, 3, 7, 2.57, 2.57, 17.14, 4.29, 3.71, 2.57, 11.57, 3.71, 2.57, 4.29, 4.29, 4.29,
+        # rubocop:enable Layout/LineLength
+        # rubocop:todo Layout/LineLength
+        4.29, 4.29, 4.29, 4.29, 4.29, 6.29, 6.29, 6.29, 2.57, 2.57, 2.57, 2.57, 2.57, 8.14, 8.14, 8.14, 8.14, 8.14,
+        # rubocop:enable Layout/LineLength
+        2.57, 8.14, 9.14, 8.14, 2.54]
+    end
+  end
+end

--- a/spec/domain/fp2024/time_record/calculation_spec.rb
+++ b/spec/domain/fp2024/time_record/calculation_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require "spec_helper"
+
+describe Fp2024::TimeRecord::Calculation do
+  let(:year) { 2024 }
+
+  let(:record) do
+    TimeRecord.new(
+      group: groups(:be), year: year,
+      total_lufeb_general: 1,
+      total_media: 2,
+      total_lufeb_specific: 3,
+      total_lufeb_promoting: 4,
+      blockkurse: 5,
+      tageskurse: 6,
+      jahreskurse: 7,
+      treffpunkte: 8,
+      beratung: 9,
+      mittelbeschaffung: 10,
+      verwaltung: 11,
+      nicht_art_74_leistungen: 12,
+
+      # lufeb general
+      auskuenfte: 13,
+      referate: 14,
+      medien_zusammenarbeit: 15,
+      sensibilisierungskampagnen: 16,
+
+      # media
+      medien_grundlagen: 17,
+      website: 18,
+      newsletter: 19,
+      videos: 20,
+      social_media: 21,
+      beratungsmodule: 22,
+      apps: 23,
+
+      # lufeb_specific
+      erarbeitung_grundlagen: 24,
+      gremien: 25,
+      vernehmlassungen: 26,
+      projekte: 27,
+
+      # lufeb_promoting
+      beratung_fachhilfeorganisationen: 28,
+      unterstuetzung_leitorgane: 29,
+      freiwilligen_akquisition: 30,
+
+      # lufeb_grundlagen
+      lufeb_grundlagen: 31,
+
+      kurse_grundlagen: 32,
+      treffpunkte_grundlagen: 33
+    )
+  end
+
+  subject { described_class.new(record) }
+
+  it "total_lufeb" do
+    expect(subject.total_lufeb).to eq 39
+  end
+
+  it "total_media" do
+    expect(subject.total_media).to eq 2
+  end
+
+  it "total_lufeb_grundlagen" do
+    expect(subject.total_lufeb_grundlagen).to eq 31
+  end
+
+  it "total_courses" do
+    expect(subject.total_courses).to eq 26 + 32 + 33
+  end
+
+  it "total_additional_person_specific" do
+    expect(subject.total_additional_person_specific).to eq 9
+  end
+
+  it "total_remaining" do
+    expect(subject.total_remaining).to eq 21
+  end
+
+  it "total_paragraph_74" do
+    expect(subject.total_paragraph_74).to eq 97 + 32 + 33
+  end
+  it "total_paragraph_74_pensum" do
+    expect(subject.total_paragraph_74_pensum).to eq (97 + 32 + 33).to_d / 1900
+  end
+
+  it "total_not_paragraph_74" do
+    expect(subject.total_not_paragraph_74).to eq 12
+  end
+  it "total_not_paragraph_74_pensum" do
+    expect(subject.total_not_paragraph_74_pensum).to eq BigDecimal(12) / 1900
+  end
+
+  it "total_pensum" do
+    expect(subject.total_pensum).to eq (12 + 97 + 32 + 33).to_d / 1900
+  end
+
+  it "update_totals" do
+    expect(subject.total_lufeb_general).to eq 1
+    expect(subject.total_lufeb_specific).to eq 3
+    expect(subject.total_lufeb_promoting).to eq 4
+    expect(subject.total_media).to eq 2
+
+    subject.update_totals
+
+    expect(subject.total_lufeb_general).to eq 58
+    expect(subject.total_lufeb_specific).to eq 102
+    expect(subject.total_lufeb_promoting).to eq 87
+    expect(subject.total_media).to eq 140
+  end
+end

--- a/spec/domain/fp2024/time_record/lufeb_pro_verein_spec.rb
+++ b/spec/domain/fp2024/time_record/lufeb_pro_verein_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2021, Insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require "spec_helper"
+
+describe Fp2024::TimeRecord::LufebProVerein do
+  let(:year) { 2024 }
+  subject { described_class.new(year) }
+
+  let(:group) { groups(:dachverein) }
+
+  it "knows a list of groups to export" do
+    expected = [
+      "insieme Schweiz",
+      "Kanton Bern",
+      "Biel-Seeland",
+      "Freiburg"
+    ]
+
+    expect(subject.vereine.map(&:name)).to match_array expected
+    expect(subject.vereine.map(&:name)).to eq expected
+  end
+
+  it "has a structured data-object for all groups" do
+    list = subject.vereine.map { |verein| subject.lufeb_data_for(verein.id) }
+
+    expect(list).to be_all described_class::Data
+  end
+
+  it "has correct data" do
+    create_time_record(
+      TimeRecord::EmployeeTime,
+      auskuenfte: 1,
+      gremien: 2,
+      beratung_fachhilfeorganisationen: 3,
+      lufeb_grundlagen: 4,
+      kurse_grundlagen: 5
+    )
+
+    create_time_record(
+      TimeRecord::VolunteerWithVerificationTime,
+      auskuenfte: 5,
+      gremien: 4,
+      beratung_fachhilfeorganisationen: 3,
+      lufeb_grundlagen: 2,
+      kurse_grundlagen: 1
+    )
+
+    data = subject.lufeb_data_for(group.id)
+
+    expect(data.general).to eq 6
+    expect(data.specific).to eq 6
+    expect(data.promoting).to eq 6
+    expect(data.lufeb_grundlagen).to eq 6
+    expect(data.kurse_grundlagen).to eq 6
+  end
+
+  private
+
+  def create_time_record(model_name, values)
+    model_name.create!(values.merge(group_id: group.id, year: year))
+  end
+end

--- a/spec/domain/fp2024/time_record/organisations_daten_spec.rb
+++ b/spec/domain/fp2024/time_record/organisations_daten_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2021-2023, Insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require "spec_helper"
+
+describe Fp2024::TimeRecord::OrganisationsDaten do
+  let(:year) { 2024 }
+  subject { described_class.new(year) }
+
+  let(:group) { groups(:dachverein) }
+
+  it "knows a list of groups to export" do
+    expected = [
+      "insieme Schweiz",
+      "Kanton Bern",
+      "Biel-Seeland",
+      "Freiburg"
+    ]
+
+    expect(subject.vereine.map(&:name)).to match_array expected
+    expect(subject.vereine.map(&:name)).to eq expected
+  end
+
+  it "has a structured data-object for all groups" do
+    list = subject.vereine.map { |verein| subject.data_for(verein) }
+
+    expect(list).to be_all described_class::Data
+  end
+
+  it "has correct data" do
+    # rubocop:todo Layout/LineLength
+    create_cost_accounting_report("honorare", aufwand_ertrag_fibu: 123_500) # 0.5 FTE, not taken into account
+    # rubocop:enable Layout/LineLength
+    create_time_report(TimeRecord::EmployeeTime, {})
+      .create_employee_pensum(paragraph_74: 0.5) # 0.5 FTE Art74
+    create_time_report(
+      TimeRecord::VolunteerWithoutVerificationTime,
+      nicht_art_74_leistungen: 475 # 0.25 FTE
+    )
+    create_time_report(
+      TimeRecord::VolunteerWithVerificationTime,
+      nicht_art_74_leistungen: 475, # 0.25 FTE
+      beratung: 2850 # 1.5 FTE Art74
+    )
+
+    data = subject.data_for(group)
+
+    expect(data.angestellte_insgesamt).to be_within(0.01).of(0.5)
+    expect(data.angestellte_art_74).to be_within(0.01).of(0.5)
+    expect(data.freiwillige_insgesamt).to be_within(0.01).of(2.0)
+    expect(data.freiwillige_art_74).to be_within(0.01).of(1.5)
+  end
+
+  private
+
+  def create_time_report(model, values)
+    model.create!(values.merge(group_id: group.id, year: year))
+  end
+
+  def create_cost_accounting_report(name, values)
+    CostAccountingRecord.create!(
+      values.merge(group_id: group.id, year: year, report: name)
+    )
+  end
+end

--- a/spec/domain/fp2024/time_record/report/capital_substrate_factor_spec.rb
+++ b/spec/domain/fp2024/time_record/report/capital_substrate_factor_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require "spec_helper"
+
+describe Fp2024::TimeRecord::Report::CapitalSubstrateFactor do
+  let(:year) { 2024 }
+
+  let(:group) { groups(:be) }
+  let(:table) { fp_class("TimeRecord::Table").new(group, year) }
+  let(:report) { table.reports.fetch("capital_substrate_factor") }
+
+  before do
+    create_course_record("tk", 8_000)
+    create_cost_accounting_report("raumaufwand", raeumlichkeiten: 1_000)
+    create_cost_accounting_report("honorare", aufwand_ertrag_fibu: 1_000, verwaltung: 100,
+      beratung: 300)
+    create_report(TimeRecord::EmployeeTime, verwaltung: 500, beratung: 300, tageskurse: 200)
+
+    CapitalSubstrate.create!(group_id: group.id, year: year, organization_capital: 50_000)
+  end
+
+  context "#paragraph_74" do
+    it "has prequisites" do
+      expect(report.send(:capital_substrate)).to be_within(0.0001).of(260_600.0)
+      expect(report.send(:vollkosten_total)).to be_within(0.0001).of(9_400.0)
+    end
+
+    it "calculates the correct value" do
+      expect(report.paragraph_74).to be_within(0.1).of(260_600.0 / 9_400.0)
+      expect(report.paragraph_74).to be_within(0.1).of(27.7)
+    end
+
+    it "handles div/0" do
+      expect(report).to receive(:vollkosten_total).and_return(0)
+
+      expect(report.paragraph_74).to be_zero
+    end
+  end
+
+  private
+
+  def create_cost_accounting_report(name, values)
+    CostAccountingRecord.create!(values.merge(group_id: group.id,
+      year: year,
+      report: name))
+  end
+
+  def create_report(model_name, values)
+    model_name.create!(values.merge(group_id: group.id, year: year))
+  end
+
+  def create_course_record(lk, honorare)
+    Event::CourseRecord.create!(
+      event: Fabricate(:aggregate_course, groups: [group], leistungskategorie: lk,
+        fachkonzept: "sport_jugend", year: year),
+      honorare_inkl_sozialversicherung: honorare
+    )
+  end
+end

--- a/spec/domain/fp2024/time_record/report/capital_substrate_limit_spec.rb
+++ b/spec/domain/fp2024/time_record/report/capital_substrate_limit_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Insieme Schweiz. This file is part of hitobito_insieme
+#  and licensed under the Affero General Public License version 3 or later. See
+#  the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require "spec_helper"
+
+describe Fp2024::TimeRecord::Report::CapitalSubstrateLimit do
+  let(:year) { 2024 }
+  let(:group) { groups(:be) }
+  let(:table) { fp_class("TimeRecord::Table").new(group, year) }
+  let(:report) { table.reports.fetch("capital_substrate_limit") }
+
+  before do
+    create_course_record("tk", 100) # -> 300
+    create_cost_accounting_report("honorare", beratung: 300) # -> 900
+  end
+
+  context "#paragraph_74" do
+    it "calculates the correct value" do
+      parameter = ReportingParameter.for(year)
+      expect(parameter.capital_substrate_limit).to eq(1.5)
+
+      expect(report.paragraph_74).to eq(600)
+    end
+  end
+
+  context "#not_paragraph_74" do
+    it "is nil" do
+      nil
+    end
+  end
+
+  context "#total" do
+    it "is nil" do
+      nil
+    end
+  end
+
+  private
+
+  def create_cost_accounting_report(name, values)
+    CostAccountingRecord.create!(values.merge(group_id: group.id,
+      year: year,
+      report: name))
+  end
+
+  def create_report(model_name, values)
+    model_name.create!(values.merge(group_id: group.id, year: year))
+  end
+
+  def create_course_record(lk, honorare)
+    Event::CourseRecord.create!(
+      event: Fabricate(:aggregate_course, groups: [group], leistungskategorie: lk,
+        fachkonzept: "sport_jugend", year: year),
+      honorare_inkl_sozialversicherung: honorare
+    )
+  end
+end

--- a/spec/domain/fp2024/time_record/report/capital_substrate_spec.rb
+++ b/spec/domain/fp2024/time_record/report/capital_substrate_spec.rb
@@ -68,8 +68,7 @@ describe Fp2024::TimeRecord::Report::CapitalSubstrate do
       cs = CapitalSubstrate.find_by(group_id: group.id, year: year)
       cs.update(previous_substrate_sum: 1650.0)
 
-      expect(report.deckungsbeitrag4_fp2015).to eq(1650.0)
-      expect(report.deckungsbeitrag4_fp2020).to eq(-150.0)
+      expect(report.deckungsbeitrag4_fp2024).to eq(-150.0)
       expect(report.deckungsbeitrag4_sum).to eq(1500.0)
     end
 
@@ -79,7 +78,7 @@ describe Fp2024::TimeRecord::Report::CapitalSubstrate do
       create_cost_accounting_report("beitraege_iv", beratung: 5_000, year: year)
       create_cost_accounting_report("beitraege_iv", beratung: 7_000, year: year + 1)
 
-      expect(report.deckungsbeitrag4_fp2020).to eq(5_000 + existing_db4)
+      expect(report.deckungsbeitrag4_fp2024).to eq(5_000 + existing_db4)
     end
   end
 

--- a/spec/domain/fp2024/time_record/report/capital_substrate_spec.rb
+++ b/spec/domain/fp2024/time_record/report/capital_substrate_spec.rb
@@ -148,6 +148,27 @@ describe Fp2024::TimeRecord::Report::CapitalSubstrate do
       # rubocop:enable Layout/LineLength
     end
 
+    it "can be calculated for VP 2024" do
+      create_cost_accounting_report("abschreibungen", year: 2024, aufwand_ertrag_fibu: 2_000,
+        abgrenzung_fibu: 100)
+      create_cost_accounting_report("beitraege_iv", year: 2024, aufwand_ertrag_fibu: 1_000)
+
+      anzahl_jahre = (2024..2024).to_a.size.to_d
+      expect(anzahl_jahre).to eql 1.0
+
+      # Note: A "raumaufwand" record with raeumlichkeiten: 100 is created in the global `before` block.
+      # TotalAufwand aggregates multiple reports, including "abschreibungen" and "raumaufwand".
+      #
+      # Therefore the calculation of gesamtkosten (aufwand_ertrag_ko_re) is:
+      #   abschreibungen: 2000 - 100 = 1900
+      #   + raumaufwand: 100
+      #   -------------------
+      #   = 2000
+      #
+      # This differs from the VP2020 test, where no raumaufwand record exists and the value remains 1900.
+      expect(subject.iv_finanzierungsgrad_fp2024).to be_within(0.00001).of((1_000.0 / (2_000.0 - 100 + 100)) / anzahl_jahre)
+    end
+
     it "can be calculated for the current year" do
       create_cost_accounting_report("abschreibungen", aufwand_ertrag_fibu: 10_000,
         abgrenzung_fibu: 100)

--- a/spec/domain/fp2024/time_record/report/capital_substrate_spec.rb
+++ b/spec/domain/fp2024/time_record/report/capital_substrate_spec.rb
@@ -121,7 +121,8 @@ describe Fp2024::TimeRecord::Report::CapitalSubstrate do
   context "IV Finanzierungsgrad" do
     it "has assumptions" do
       expect((2015..2019).to_a.size).to eq 5
-      expect((2020..2024).to_a.size).to eq 3
+      expect((2020..2022).to_a.size).to eq 3
+      expect((2023..2024).to_a.size).to eq 2
     end
 
     it "can be calculated for VP 2015" do
@@ -140,8 +141,8 @@ describe Fp2024::TimeRecord::Report::CapitalSubstrate do
         abgrenzung_fibu: 100)
       create_cost_accounting_report("beitraege_iv", year: 2020, aufwand_ertrag_fibu: 1_000)
 
-      anzahl_jahre = (2020..year).to_a.size.to_d
-      expect(anzahl_jahre).to eql 3.0
+      anzahl_jahre = (2020..2023).to_a.size.to_d
+      expect(anzahl_jahre).to eql 4.0
 
       # rubocop:todo Layout/LineLength
       expect(subject.iv_finanzierungsgrad_fp2020).to be_within(0.00001).of((1_000.0 / (2_000.0 - 100)) / anzahl_jahre)
@@ -197,11 +198,11 @@ describe Fp2024::TimeRecord::Report::CapitalSubstrate do
     end
 
     it "returns current year if within bounds" do
-      expect(subject.current_or(2024, 2023)).to eql 2024
+      expect(subject.current_or(2023, 2024)).to eql 2024
     end
 
     it "return lower bound if below" do
-      expect(subject.current_or(2024, 2023)).to eql 2024
+      expect(subject.current_or(2025, 2026)).to eql 2025
     end
 
     it "return uppper bound if above" do

--- a/spec/domain/fp2024/time_record/report/capital_substrate_spec.rb
+++ b/spec/domain/fp2024/time_record/report/capital_substrate_spec.rb
@@ -1,0 +1,227 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024-2024, Insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require "spec_helper"
+
+describe Fp2024::TimeRecord::Report::CapitalSubstrate do
+  let(:year) { 2024 }
+
+  let(:group) { groups(:be) }
+  let(:table) { fp_class("TimeRecord::Table").new(group, year) }
+
+  subject(:report) { table.reports.fetch("capital_substrate") }
+
+  before do
+    create_course_record("tk", 10)
+    create_cost_accounting_report("raumaufwand", raeumlichkeiten: 100)
+    create_cost_accounting_report("honorare", aufwand_ertrag_fibu: 100, verwaltung: 10,
+      beratung: 30)
+    create_report(TimeRecord::EmployeeTime, verwaltung: 50, beratung: 30, tageskurse: 20)
+    CapitalSubstrate.create!(group_id: group.id, year: year, organization_capital: 300_000)
+  end
+
+  context "#allocation_base" do
+    it "is 0 if total_aufwand is zero" do
+      CostAccountingRecord.find_by(group_id: group.id, year: year, report: "honorare")
+        .update(aufwand_ertrag_fibu: 0)
+
+      expect(report.allocation_base).to eq(0)
+    end
+
+    it "calculates the correct value if total_aufwand is nonzero" do
+      expect(report.allocation_base).to eq(1.5)
+    end
+  end
+
+  context "#organization_capital_allocated" do
+    it "calculates the correct value" do
+      expect(report.organization_capital_allocated).to eq(450_000)
+    end
+  end
+
+  context "#deckungsbeitrag4" do
+    it "calculates the correct value" do
+      expect(report.deckungsbeitrag4).to eq(-150)
+    end
+
+    it "is 0 if beiträge exceed threshold" do
+      create_cost_accounting_report("beitraege_iv", beratung: 400_000)
+      expect(report.table.cost_accounting_value_of("beitraege_iv", "total")).to eq(400_000)
+      expect(report.class::DECKUNGSBEITRAG4_THRESHOLD).to eq(300_000.0)
+
+      expect(report.deckungsbeitrag4).to eq(0)
+    end
+
+    it "is 0 if beiträge match threshold exactly" do
+      create_cost_accounting_report("beitraege_iv", beratung: 300_000)
+      expect(report.table.cost_accounting_value_of("beitraege_iv", "total")).to eq(300_000)
+      expect(report.class::DECKUNGSBEITRAG4_THRESHOLD).to eq(300_000.0)
+
+      expect(report.deckungsbeitrag4).to eq(0)
+    end
+
+    it "includes persisted sum of previous years" do
+      cs = CapitalSubstrate.find_by(group_id: group.id, year: year)
+      cs.update(previous_substrate_sum: 1650.0)
+
+      expect(report.deckungsbeitrag4_fp2015).to eq(1650.0)
+      expect(report.deckungsbeitrag4_fp2020).to eq(-150.0)
+      expect(report.deckungsbeitrag4_sum).to eq(1500.0)
+    end
+
+    it "does not include future years" do
+      existing_db4 = -150.0
+
+      create_cost_accounting_report("beitraege_iv", beratung: 5_000, year: year)
+      create_cost_accounting_report("beitraege_iv", beratung: 7_000, year: year + 1)
+
+      expect(report.deckungsbeitrag4_fp2020).to eq(5_000 + existing_db4)
+    end
+  end
+
+  context "#exemption" do
+    it "calculates the correct value" do
+      expect(report.exemption).to eq(-200_000)
+    end
+
+    it "is 0 if no reporting_parameter is set" do
+      ReportingParameter.delete_all # necessary due to the way they are loaded
+
+      expect(ReportingParameter.for(year)).to be_nil
+      expect(report.exemption).to eq(0)
+    end
+  end
+
+  context "#paragraph_74 and #capital_substrate_allocated" do
+    it "calculates the correct value" do
+      expect(report.paragraph_74).to eq(249_850)
+
+      expect(report.capital_substrate_allocated).to eq(report.paragraph_74)
+    end
+  end
+
+  context "#capital_substrate_allocated" do
+    it "does not include fund_building" do
+      calculated = 249_850
+
+      expect(report.capital_substrate_allocated).to eq(calculated)
+
+      capital_substrate = CapitalSubstrate.find_by(year: year)
+      capital_substrate.update(fund_building: 1000)
+      expect(capital_substrate.fund_building.to_i).to_not be_zero
+
+      expect(report.capital_substrate_allocated).to eq(calculated)
+    end
+  end
+
+  context "IV Finanzierungsgrad" do
+    it "has assumptions" do
+      expect((2015..2019).to_a.size).to eq 5
+      expect((2020..2024).to_a.size).to eq 3
+    end
+
+    it "can be calculated for VP 2015" do
+      {
+        2015 => [2_000, 200]
+      }.each do |year, (aufwand, beitraege)|
+        create_cost_accounting_report("abschreibungen", year: year, aufwand_ertrag_fibu: aufwand)
+        create_cost_accounting_report("beitraege_iv", year: year, aufwand_ertrag_fibu: beitraege)
+      end
+
+      expect(subject.iv_finanzierungsgrad_fp2015).to eql(0.1 / 5)
+    end
+
+    it "can be calculated for VP 2020" do
+      create_cost_accounting_report("abschreibungen", year: 2020, aufwand_ertrag_fibu: 2_000,
+        abgrenzung_fibu: 100)
+      create_cost_accounting_report("beitraege_iv", year: 2020, aufwand_ertrag_fibu: 1_000)
+
+      anzahl_jahre = (2020..year).to_a.size.to_d
+      expect(anzahl_jahre).to eql 3.0
+
+      # rubocop:todo Layout/LineLength
+      expect(subject.iv_finanzierungsgrad_fp2020).to be_within(0.00001).of((1_000.0 / (2_000.0 - 100)) / anzahl_jahre)
+      # rubocop:enable Layout/LineLength
+    end
+
+    it "can be calculated for the current year" do
+      create_cost_accounting_report("abschreibungen", aufwand_ertrag_fibu: 10_000,
+        abgrenzung_fibu: 100)
+      create_cost_accounting_report("beitraege_iv", aufwand_ertrag_fibu: 1_000)
+
+      expect(subject.iv_finanzierungsgrad_current).to eql 0.1
+    end
+
+    it "returns zero if no aufwand was recorded" do
+      create_cost_accounting_report("abschreibungen", year: 2015, aufwand_ertrag_fibu: 0)
+
+      expect(subject.iv_finanzierungsgrad_fp2015).to eql 0.0
+    end
+
+    it "calculates average over whole VP" do
+      {
+        2015 => [2_000, 200], # 0.1
+        2016 => [1_000, 200], # 0.2
+        2017 => [1_000, 200], # 0.2
+        2018 => [500, 200], # 0.4
+        2019 => [200, 200] # 1.0
+        # 1.9 / 5 = 0.38
+      }.each do |year, (aufwand, beitraege)|
+        create_cost_accounting_report("beitraege_iv", year: year, aufwand_ertrag_fibu: beitraege)
+        create_cost_accounting_report("abschreibungen", year: year, aufwand_ertrag_fibu: aufwand)
+      end
+
+      expect(subject.iv_finanzierungsgrad_fp2015).to be_within(0.01).of(0.38)
+    end
+  end
+
+  context "#not_paragraph_74" do
+    it "is nil" do
+      nil
+    end
+  end
+
+  context "#total" do
+    it "is nil" do
+      nil
+    end
+  end
+
+  context "current year within bounds" do
+    it "has assumptions" do
+      expect(year).to eql 2024
+    end
+
+    it "returns current year if within bounds" do
+      expect(subject.current_or(2024, 2023)).to eql 2024
+    end
+
+    it "return lower bound if below" do
+      expect(subject.current_or(2024, 2023)).to eql 2024
+    end
+
+    it "return uppper bound if above" do
+      expect(subject.current_or(2015, 2019)).to eql 2019
+    end
+  end
+
+  def create_cost_accounting_report(name, values)
+    CostAccountingRecord.create!(values.reverse_merge(group_id: group.id, year: year, report: name))
+  end
+
+  def create_report(model_name, values)
+    model_name.create!(values.merge(group_id: group.id, year: year))
+  end
+
+  def create_course_record(lk, honorare)
+    Event::CourseRecord.create!(
+      event: Fabricate(:aggregate_course, groups: [group], leistungskategorie: lk,
+        fachkonzept: "sport_jugend", year: year),
+      honorare_inkl_sozialversicherung: honorare
+    )
+  end
+end

--- a/spec/domain/fp2024/time_record/report/employee_time_spec.rb
+++ b/spec/domain/fp2024/time_record/report/employee_time_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024-2023, Insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require "spec_helper"
+
+describe Fp2024::TimeRecord::Report::EmployeeTime do
+  let(:year) { 2024 }
+  let(:group) { groups(:be) }
+  let(:table) { fp_class("TimeRecord::Table").new(group, year) }
+  let(:report) { table.reports.fetch("employee_time") }
+
+  subject { report }
+
+  before do
+    create_report(TimeRecord::EmployeeTime, blockkurse: (3 * 1900),
+      nicht_art_74_leistungen: (5 * 1900))
+
+    # honorar_costs for 1 fte
+    create_report(CostAccountingRecord, report: "honorare", aufwand_ertrag_fibu: (130 * 1900),
+      beratung: (2 * 130 * 1900))
+  end
+
+  context "#paragraph_74" do
+    it "calculates the correct value" do
+      expect(report.paragraph_74).to eq BigDecimal(3)
+    end
+  end
+
+  context "#not_paragraph_74" do
+    it "calculates the correct value" do
+      expect(report.not_paragraph_74).to eq BigDecimal(5)
+    end
+  end
+
+  context "#total" do
+    it "calculates the correct value" do
+      expect(report.total).to eq(BigDecimal(3) + BigDecimal(5)) # 8
+    end
+  end
+
+  def create_report(model_name, values)
+    model_name.create!(values.merge(group_id: group.id, year: year))
+  end
+end

--- a/spec/fabricators/date_fabricator.rb
+++ b/spec/fabricators/date_fabricator.rb
@@ -17,3 +17,8 @@ Fabricator(:fp2022_date, from: :event_date) do
   start_at { Date.new(2022, 12, 1) }
   finish_at { |date| date[:start_at] + 7.days }
 end
+
+Fabricator(:fp2024_date, from: :event_date) do
+  start_at { Date.new(2024, 1, 1) }
+  finish_at { |date| date[:start_at] + 7.days }
+end

--- a/spec/models/fp2024/event/course_record_spec.rb
+++ b/spec/models/fp2024/event/course_record_spec.rb
@@ -1,0 +1,88 @@
+#  Copyright (c) 2012-2021, insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require "spec_helper"
+
+describe Event::CourseRecord do
+  let(:group) { groups(:be) }
+  let(:year) { 2024 }
+
+  def new_record(event, attrs = {})
+    event.course_record.try(:destroy!)
+    r = Event::CourseRecord.new(attrs.merge(event: event, year: year))
+    r.valid?
+    r
+  end
+
+  context "treffpunkt courses" do
+    let(:event) do
+      event = Fabricate(:course, groups: [group], leistungskategorie: "tp",
+        fachkonzept: "treffpunkt")
+      event.dates = [
+        Fabricate(:event_date, start_at: Date.new(2024, 3, 16))
+      ]
+      event
+    end
+
+    subject(:record) do
+      new_record(event, {
+        betreuerinnen: 2,
+        kursdauer: 2,
+        honorare_inkl_sozialversicherung: 60, # -> direkter_aufwand
+        gemeinkostenanteil: 20
+      })
+    end
+
+    it "calculates vollkosten pro betreuungsstunde" do
+      expect(record.year).to eq 2024
+      expect(record.betreuungsstunden).to eq(BigDecimal(4))
+      expect(record.vollkosten_pro_betreuungsstunde).to eq(BigDecimal(20))
+    end
+
+    it "handles division by zero" do
+      record.betreuerinnen = 0
+      record.set_cached_values # trigger before-validation hook to update values
+
+      expect(record.year).to eq 2024
+      expect(record.vollkosten_pro_betreuungsstunde).to eq(BigDecimal(0))
+    end
+  end
+
+  context "treffpunkt aggregate courses" do
+    let(:event) do
+      event = Fabricate(:aggregate_course, groups: [group], leistungskategorie: "tp",
+        fachkonzept: "treffpunkt")
+      event.dates = [
+        Fabricate(:event_date, start_at: Date.new(2024, 3, 16))
+      ]
+      event
+    end
+
+    subject(:record) do
+      new_record(event, {
+        betreuerinnen: 2,
+        kursdauer: 2,
+        betreuungsstunden: 4,
+        honorare_inkl_sozialversicherung: 60, # -> direkter_aufwand
+        gemeinkostenanteil: 20
+      })
+    end
+
+    it "calculates vollkosten pro betreuungsstunde" do
+      expect(subject.year).to eq 2024
+      expect(subject.betreuungsstunden).to eq(BigDecimal(4))
+      expect(subject.direkter_aufwand).to eq(60)
+      expect(subject.gemeinkostenanteil).to eq(20)
+      expect(subject.total_vollkosten).to eq(BigDecimal(80))
+      expect(subject.vollkosten_pro_betreuungsstunde).to eq(BigDecimal(20))
+    end
+
+    it "handles division by zero" do
+      record.betreuungsstunden = 0
+      expect(record.year).to eq 2024
+      expect(record.vollkosten_pro_betreuungsstunde).to eq(BigDecimal(0))
+    end
+  end
+end

--- a/spec/models/fp2024/time_record_spec.rb
+++ b/spec/models/fp2024/time_record_spec.rb
@@ -1,0 +1,208 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Insieme Schweiz. This file is part of
+#  hitobito_insieme and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_insieme.
+
+require "spec_helper"
+
+describe TimeRecord do
+  let(:year) { 2024 }
+
+  let(:record) do
+    TimeRecord.new(group: groups(:be), year: year,
+      total_lufeb_general: 1,
+      total_media: 2,
+      total_lufeb_specific: 3,
+      total_lufeb_promoting: 4,
+      blockkurse: 5,
+      tageskurse: 6,
+      jahreskurse: 7,
+      treffpunkte: 8,
+      beratung: 9,
+      mittelbeschaffung: 10,
+      verwaltung: 11,
+      nicht_art_74_leistungen: 12,
+
+      # lufeb general
+      auskuenfte: 13,
+      referate: 14,
+      medien_zusammenarbeit: 15,
+      sensibilisierungskampagnen: 16,
+
+      # media
+      medien_grundlagen: 17,
+      website: 18,
+      newsletter: 19,
+      videos: 20,
+      social_media: 21,
+      beratungsmodule: 22,
+      apps: 23,
+
+      # lufeb_specific
+      erarbeitung_grundlagen: 24,
+      gremien: 25,
+      vernehmlassungen: 26,
+      projekte: 27,
+
+      # lufeb_promoting
+      beratung_fachhilfeorganisationen: 28,
+      unterstuetzung_leitorgane: 29,
+      freiwilligen_akquisition: 30)
+  end
+
+  context "calculated totals" do
+    context "#total_lufeb" do
+      it "is 0 for new record" do
+        expect(TimeRecord.new.total_lufeb).to eq(0)
+      end
+
+      it "is the sum the values set" do
+        expect(record.total_lufeb).to eq 8
+      end
+    end
+
+    context "#total_courses" do
+      it "is 0 for new record" do
+        expect(TimeRecord.new.total_courses).to eq(0)
+      end
+
+      it "is the sum the values set" do
+        expect(record.total_courses).to eq 26
+      end
+    end
+
+    context "#total_additional_person_specific" do
+      it "is 0 for new record" do
+        expect(TimeRecord.new.total_additional_person_specific).to eq(0)
+      end
+
+      it "is the sum the values set" do
+        expect(record.total_additional_person_specific).to eq 9
+      end
+    end
+
+    context "#total_remaining" do
+      it "is 0 for new record" do
+        expect(TimeRecord.new.total_remaining).to eq(0)
+      end
+
+      it "is the sum the values set" do
+        expect(record.total_remaining).to eq 21
+      end
+    end
+
+    context "#total_paragraph_74" do
+      it "is 0 for new record" do
+        expect(TimeRecord.new.total_paragraph_74).to eq(0)
+      end
+
+      it "is the sum the values set" do
+        expect(record.total_paragraph_74).to eq 66
+      end
+    end
+
+    context "#total_not_paragraph_74" do
+      it "is 0 for new record" do
+        expect(TimeRecord.new.total_not_paragraph_74).to eq(0)
+      end
+
+      it "is the sum the values set" do
+        expect(record.total_not_paragraph_74).to eq 12
+      end
+    end
+  end
+
+  context "stored totals" do
+    context "#update_totals" do
+      it "is called on save" do
+        expect(record).to receive(:update_totals)
+
+        record.type = "TimeRecord::EmployeeTime"
+        record.save!
+      end
+    end
+
+    [[:total_lufeb_general, 58],
+      [:total_lufeb_private, nil],
+      [:total_lufeb_specific, 102],
+      [:total_lufeb_promoting, 87],
+      [:total_media, 140],
+      [:total, 455]].each do |method, value|
+      context "##{method}" do
+        if method == :total
+          it "is 0 for new record before save" do
+            expect(TimeRecord.new.send(method)).to eq 0
+          end
+        else
+          it "is nil for new record before save" do
+            expect(TimeRecord.new.send(method)).to be_nil
+          end
+        end
+
+        it "is 0 for new record after save" do
+          new_record = TimeRecord.new(group: groups(:be), year: year,
+            type: "TimeRecord::EmployeeTime")
+          new_record.save!
+          expected = value.present? ? 0 : nil
+          expect(new_record.send(method)).to eq(expected)
+        end
+
+        it "is the correct sum for nonempty record" do
+          record.type = "TimeRecord::EmployeeTime"
+          record.save!
+          expect(record.send(method)).to eq(value)
+        end
+      end
+    end
+  end
+
+  context "pensums" do
+    it "exists a bsv_hours_per_year reporting parameter" do
+      expect(ReportingParameter.for(year).bsv_hours_per_year).to eq 1900
+    end
+
+    context "#total_paragraph_74_pensum" do
+      it "is 0 for new record" do
+        expect(TimeRecord.new(year: year).total_paragraph_74_pensum).to eq(0)
+      end
+
+      it "is the equivalent to 100%-jobs" do
+        expect(record.total_paragraph_74).to eq 66
+        expect(record.total_paragraph_74_pensum).to eq BigDecimal(66) / 1900
+      end
+    end
+
+    context "#total_not_paragraph_74_pensum" do
+      it "is 0 for new record" do
+        expect(TimeRecord.new(year: year).total_not_paragraph_74_pensum).to eq(0)
+      end
+
+      it "is the equivalent to 100%-jobs" do
+        expect(record.total_not_paragraph_74).to eq 12
+        expect(record.total_not_paragraph_74_pensum).to eq BigDecimal(12) / 1900
+      end
+    end
+
+    context "#total_pensum" do
+      it "is 0 for new record before save" do
+        expect(TimeRecord.new(year: year).total_pensum).to eq(0)
+      end
+
+      it "is 0 for new record after save" do
+        new_record = TimeRecord.new(group: groups(:be), year: year,
+          type: "TimeRecord::EmployeeTime")
+        new_record.save!
+        expect(new_record.total_pensum).to eq(0)
+      end
+
+      it "is the equivalent to 100%-jobs" do
+        record.type = "TimeRecord::EmployeeTime"
+        record.save!
+        expect(record.total).to eq 455
+        expect(record.total_pensum).to eq BigDecimal(455) / 1900
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Ziel
- neue Fp2024 hinzugefügt; diese entspricht der BSV-Vertragsperiode 2024-2027
- UI stellt KPIs (Deckungsbeitrag 4, IV-Finanzierungsgrad) für VP 2024-2027 korrekt dar

## Umsetzung
- erstelle neue fp2024 via Rake-Task `rake fp:new[2024]`
- `app/domain/fp2024/time_record/report/capital_substrate.rb` -> ergänze db4 und ivfg für VP2024-2027; passe ältere VPs entsprechend an
- `app/views/fp2024/capital_substrate/edit.html.haml` -> ersetzte VP2015-2019 mit VP2024-2027
- `config/locales/ .` -> ergänze locales wo nötig
- `spec/domain/fp2024/time_record/report/capital_substrate_spec.rb` -> ergänze Test für VP2024-2027

## Ergebnis
- neue fp2024 deckt BSV-Vertragsperiode 2024-2027 ab
- UI bildet neu KPIs für BSV-Vertragsperioden 2020-2023 und 2024-2027 ab (alt: 2015-2019 & 2020-2023)

## ToDo
- [x] erstelle fp2024 mit Rake-Task
- [x] erledige Aufgaben gemäss Checkliste Rake-Task 
- [x] Implementierung db4 und ivfg für VP2024-2027
- [x] Update views
- [x] Update locales
- [x] Update spec
- [x] Manuelle Tests: Jahre durcklicken -> UI auf korrekte Ausgaben checken
- [x] Update CHANGELOG.md